### PR TITLE
Improve threaded/non-threaded paths

### DIFF
--- a/.github/workflows/macos-custom-marian-native.yml
+++ b/.github/workflows/macos-custom-marian-native.yml
@@ -2,9 +2,9 @@ name: MacOS Native (Custom)
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, ci-sandbox ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, ci-sandbox ]
 
 jobs:
   build-macos:

--- a/.github/workflows/macos-custom-marian-wasm.yml
+++ b/.github/workflows/macos-custom-marian-wasm.yml
@@ -2,9 +2,9 @@ name: MacOS WASM (Custom)
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, ci-sandbox ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, ci-sandbox ]
 
 jobs:
   build-wasm:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -39,7 +39,7 @@ jobs:
           -DUSE_FBGEMM=on \
           -DUSE_SENTENCEPIECE=on \
           -DUSE_STATIC_LIBS=off \
-          -DUSE_WASM_COMPATIBLE_MARIAN=off
+          -DUSE_WASM_COMPATIBLE_SOURCES=off
 
     - name: Compile
       working-directory: build

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -2,9 +2,9 @@ name: MacOS
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, ci-sandbox ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, ci-sandbox ]
 
 jobs:
   build-macos:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -97,7 +97,7 @@ jobs:
           -DUSE_FBGEMM=${{ matrix.cpu }} \
           -DUSE_SENTENCEPIECE=on \
           -DUSE_STATIC_LIBS=on \
-          -DUSE_WASM_COMPATIBLE_MARIAN=off
+          -DUSE_WASM_COMPATIBLE_SOURCES=off
 
     - name: Compile
       working-directory: build

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -2,9 +2,9 @@ name: Ubuntu
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, ci-sandbox ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, ci-sandbox ]
 
 jobs:
   build-ubuntu:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,9 +2,9 @@ name: Windows
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, ci-sandbox ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, ci-sandbox ]
 
 env:
   MKL_URL: "https://romang.blob.core.windows.net/mariandev/ci/mkl-2020.1-windows-static.zip"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,16 +13,14 @@ include(CMakeDependentOption)
 
 # Project specific cmake options
 option(COMPILE_WASM "Compile for WASM" OFF)
-option(USE_WASM_COMPATIBLE_MARIAN "Use wasm compatible marian backend" ON)
-CMAKE_DEPENDENT_OPTION(COMPILE_THREAD_VARIANT "Compile the project with thread support" OFF
-                       "USE_WASM_COMPATIBLE_MARIAN" ON)
+option(USE_WASM_COMPATIBLE_SOURCES "Use wasm compatible sources" ON)
 SET(PACKAGE_DIR "" CACHE STRING "Directory including all the files to be packaged (pre-loaded) in wasm builds")
 
 # Set marian (3rd party submodule) cmake options to compile for this project
 SET(COMPILE_CUDA OFF CACHE BOOL "Compile GPU version")
 SET(USE_SENTENCEPIECE ON CACHE BOOL "Download and compile SentencePiece")
 SET(USE_STATIC_LIBS ON CACHE BOOL "Link statically against non-system libs")
-if (USE_WASM_COMPATIBLE_MARIAN)
+if (USE_WASM_COMPATIBLE_SOURCES)
   # If using wasm compatible marian then set following flags
   SET(COMPILE_LIBRARY_ONLY ON CACHE BOOL "Build only the Marian library and exclude all executables.")
   SET(USE_MKL OFF CACHE BOOL "Compile with MKL support")
@@ -37,7 +35,7 @@ if (USE_WASM_COMPATIBLE_MARIAN)
 endif()
 # Set ssplit (3rd party submodule) cmake options to compile for this project
 CMAKE_DEPENDENT_OPTION(USE_INTERNAL_PCRE2 "Use internal PCRE2 instead of system PCRE2" ON
-                       "USE_WASM_COMPATIBLE_MARIAN" OFF)
+                       "USE_WASM_COMPATIBLE_SOURCES" OFF)
 
 # Documentation: https://cliutils.gitlab.io/modern-cmake/chapters/projects/submodule.html
 # Ensures the submodules are set correctly during a build.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,9 +67,9 @@ endif(COMPILE_WASM)
 
 add_subdirectory(3rd_party)
 add_subdirectory(src)
-if(NOT COMPILE_WASM)
-  add_subdirectory(app)
-endif()
+
 if(COMPILE_WASM)
   add_subdirectory(wasm)
+else()
+  add_subdirectory(app)
 endif(COMPILE_WASM)

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,8 +1,10 @@
 add_executable(bergamot-translator-app main.cpp)
 target_link_libraries(bergamot-translator-app PRIVATE bergamot-translator)
 
-add_executable(service-cli main-mts.cpp)
-target_link_libraries(service-cli PRIVATE bergamot-translator)
+if (NOT USE_WASM_COMPATIBLE_SOURCES)
+    add_executable(service-cli main-mts.cpp)
+    target_link_libraries(service-cli PRIVATE bergamot-translator)
 
-add_executable(marian-decoder-new marian-decoder-new.cpp)
-target_link_libraries(marian-decoder-new PRIVATE bergamot-translator)
+    add_executable(marian-decoder-new marian-decoder-new.cpp)
+    target_link_libraries(marian-decoder-new PRIVATE bergamot-translator)
+endif()

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,10 +1,8 @@
 add_executable(bergamot-translator-app main.cpp)
 target_link_libraries(bergamot-translator-app PRIVATE bergamot-translator)
 
-if (NOT COMPILE_WASM)
-    add_executable(service-cli main-mts.cpp)
-    target_link_libraries(service-cli PRIVATE bergamot-translator)
+add_executable(service-cli main-mts.cpp)
+target_link_libraries(service-cli PRIVATE bergamot-translator)
 
-    add_executable(marian-decoder-new marian-decoder-new.cpp)
-    target_link_libraries(marian-decoder-new PRIVATE bergamot-translator)
-endif()
+add_executable(marian-decoder-new marian-decoder-new.cpp)
+target_link_libraries(marian-decoder-new PRIVATE bergamot-translator)

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,8 +1,10 @@
 add_executable(bergamot-translator-app main.cpp)
 target_link_libraries(bergamot-translator-app PRIVATE bergamot-translator)
 
-add_executable(service-cli main-mts.cpp)
-target_link_libraries(service-cli PRIVATE bergamot-translator)
+if (NOT COMPILE_WASM)
+    add_executable(service-cli main-mts.cpp)
+    target_link_libraries(service-cli PRIVATE bergamot-translator)
 
-add_executable(marian-decoder-new marian-decoder-new.cpp)
-target_link_libraries(marian-decoder-new PRIVATE bergamot-translator)
+    add_executable(marian-decoder-new marian-decoder-new.cpp)
+    target_link_libraries(marian-decoder-new PRIVATE bergamot-translator)
+endif()

--- a/doc/marian-integration.md
+++ b/doc/marian-integration.md
@@ -10,7 +10,7 @@ $ git clone https://github.com/browsermt/bergamot-translator
 $ cd bergamot-translator
 $ mkdir build
 $ cd build
-$ cmake .. -DUSE_WASM_COMPATIBLE_MARIAN=off -DCMAKE_BUILD_TYPE=Release
+$ cmake .. -DUSE_WASM_COMPATIBLE_SOURCES=off -DCMAKE_BUILD_TYPE=Release
 $ make -j
 ```
 

--- a/src/translator/CMakeLists.txt
+++ b/src/translator/CMakeLists.txt
@@ -1,3 +1,7 @@
+if (NOT COMPILE_WASM)
+    set(SERVICE "service.cpp")
+endif()
+
 add_library(bergamot-translator STATIC
     AbstractTranslationModel.cpp
     TranslationModel.cpp
@@ -8,7 +12,8 @@ add_library(bergamot-translator STATIC
     batch_translator.cpp 
     multifactor_priority.cpp 
     request.cpp 
-    service.cpp
+    service_base.cpp
+    ${SERVICE}
     batcher.cpp
     response.cpp
     batch.cpp

--- a/src/translator/CMakeLists.txt
+++ b/src/translator/CMakeLists.txt
@@ -1,5 +1,5 @@
-if (NOT COMPILE_WASM)
-    set(SERVICE "service.cpp")
+if (NOT USE_WASM_COMPATIBLE_SOURCES)
+    set(MULTITHREADED_SERVICE_SOURCE "service.cpp")
 endif()
 
 add_library(bergamot-translator STATIC
@@ -13,7 +13,7 @@ add_library(bergamot-translator STATIC
     multifactor_priority.cpp 
     request.cpp 
     service_base.cpp
-    ${SERVICE}
+    ${MULTITHREADED_SERVICE_SOURCE}
     batcher.cpp
     response.cpp
     batch.cpp
@@ -31,10 +31,6 @@ if(COMPILE_WASM)
   target_compile_definitions(bergamot-translator PRIVATE WASM_BINDINGS)
   target_compile_options(bergamot-translator PRIVATE ${WASM_COMPILE_FLAGS})
 endif(COMPILE_WASM)
-
-if (COMPILE_THREAD_VARIANT)
-  target_compile_definitions(bergamot-translator PRIVATE WITH_PTHREADS)
-endif()
 
 target_link_libraries(bergamot-translator marian ssplit)
 

--- a/src/translator/TranslationModel.cpp
+++ b/src/translator/TranslationModel.cpp
@@ -15,7 +15,7 @@
 // All local project includes
 #include "TranslationModel.h"
 #include "translator/parser.h"
-#include "translator/service.h"
+#include "translator/service_base.h"
 
 std::shared_ptr<marian::Options> parseOptions(const std::string &config) {
   marian::Options options;

--- a/src/translator/TranslationModel.h
+++ b/src/translator/TranslationModel.h
@@ -16,7 +16,7 @@
 
 // All local project includes
 #include "AbstractTranslationModel.h"
-#include "translator/service.h"
+#include "translator/service_base.h"
 
 /* A Translation model that translates a plain (without any markups and emojis)
  * UTF-8 encoded text. This implementation supports translation from 1 source
@@ -55,9 +55,8 @@ public:
    * entry of texts list will be moved to its corresponding TranslationResult
    * object).
    */
-  std::vector<TranslationResult>
-  translate(std::vector<std::string> &&texts,
-            TranslationRequest request) override;
+  std::vector<TranslationResult> translate(std::vector<std::string> &&texts,
+                                           TranslationRequest request) override;
 
   /* Check if the model can provide alignment information b/w original and
    * translated text. */
@@ -66,7 +65,7 @@ public:
 private:
   // Model configuration options
   std::shared_ptr<marian::Options> configOptions_; // ORDER DEPENDECNY
-  marian::bergamot::Service service_;              // ORDER DEPENDENCY
+  marian::bergamot::NonThreadedService service_;   // ORDER DEPENDENCY
 };
 
 #endif /* SRC_TRANSLATOR_TRANSLATIONMODEL_H_ */

--- a/src/translator/batch_translator.cpp
+++ b/src/translator/batch_translator.cpp
@@ -96,22 +96,5 @@ void BatchTranslator::translate(Batch &batch) {
   batch.completeBatch(histories);
 }
 
-#ifdef WITH_PTHREADS
-
-void BatchTranslator::consumeFrom(PCQueue<Batch> &pcqueue) {
-  Batch batch;
-  Histories histories;
-  while (true) {
-    pcqueue.ConsumeSwap(batch);
-    if (batch.isPoison()) {
-      return;
-    } else {
-      translate(batch);
-    }
-  }
-}
-
-#endif
-
 } // namespace bergamot
 } // namespace marian

--- a/src/translator/batch_translator.h
+++ b/src/translator/batch_translator.h
@@ -34,10 +34,6 @@ public:
   void translate(Batch &batch);
   void initialize();
 
-#ifdef WITH_PTHREADS
-  void consumeFrom(PCQueue<Batch> &pcqueue);
-#endif
-
 private:
   Ptr<Options> options_;
   DeviceId device_;

--- a/src/translator/batcher.cpp
+++ b/src/translator/batcher.cpp
@@ -57,14 +57,5 @@ void Batcher::addWholeRequest(Ptr<Request> request) {
   }
 }
 
-#ifdef WITH_PTHREADS
-void Batcher::produceTo(PCQueue<Batch> &pcqueue) {
-  Batch batch;
-  while (cleaveBatch(batch)) {
-    pcqueue.ProduceSwap(batch);
-  }
-}
-#endif
-
 } // namespace bergamot
 } // namespace marian

--- a/src/translator/batcher.h
+++ b/src/translator/batcher.h
@@ -25,16 +25,13 @@ public:
   // which maintains priority among sentences from multiple concurrent requests.
   void addSentenceWithPriority(RequestSentence &sentence);
   void addWholeRequest(Ptr<Request> request);
-#ifdef WITH_PTHREADS
-  void produceTo(PCQueue<Batch> &pcqueue);
-#endif
 
+  bool operator>>(Batch &batch); // alias for cleaveBatch
+
+private:
   // Loads sentences with sentences compiled from (tentatively) multiple
   // requests optimizing for both padding and priority.
   bool cleaveBatch(Batch &batch);
-  bool operator>>(Batch &batch); // alias
-
-private:
   size_t miniBatchWords;
   std::vector<std::set<RequestSentence>> bucket_;
   size_t batchNumber_{0};

--- a/src/translator/service.cpp
+++ b/src/translator/service.cpp
@@ -11,8 +11,9 @@ namespace bergamot {
 Service::Service(Ptr<Options> options)
     : ServiceBase(options), numWorkers_(options->get<int>("cpu-threads")),
       pcqueue_(numWorkers_) {
-  if (numWorkers_ <= 0) {
-    ABORT("Fatal: numWorkers should be greater than 1");
+  if (numWorkers_ == 0) {
+    ABORT("Fatal: Attempt to create multithreaded instance with --cpu-threads "
+          "0. ");
   }
 
   translators_.reserve(numWorkers_);

--- a/src/translator/service.cpp
+++ b/src/translator/service.cpp
@@ -65,24 +65,5 @@ void Service::stop() {
 
 Service::~Service() { stop(); }
 
-// Internal function nobody used, only within service.
-std::vector<Ptr<const Vocab>> loadVocabularies(Ptr<Options> options) {
-  // @TODO: parallelize vocab loading for faster startup
-  auto vfiles = options->get<std::vector<std::string>>("vocabs");
-  // with the current setup, we need at least two vocabs: src and trg
-  ABORT_IF(vfiles.size() < 2, "Insufficient number of vocabularies.");
-  std::vector<Ptr<Vocab const>> vocabs(vfiles.size());
-  std::unordered_map<std::string, Ptr<Vocab>> vmap;
-  for (size_t i = 0; i < vocabs.size(); ++i) {
-    auto m = vmap.emplace(std::make_pair(vfiles[i], Ptr<Vocab>()));
-    if (m.second) { // new: load the vocab
-      m.first->second = New<Vocab>(options, i);
-      m.first->second->load(vfiles[i]);
-    }
-    vocabs[i] = m.first->second;
-  }
-  return vocabs;
-}
-
 } // namespace bergamot
 } // namespace marian

--- a/src/translator/service.h
+++ b/src/translator/service.h
@@ -1,4 +1,3 @@
-
 #ifndef SRC_BERGAMOT_SERVICE_H_
 #define SRC_BERGAMOT_SERVICE_H_
 
@@ -43,8 +42,6 @@ private:
   std::vector<std::thread> workers_;
   std::vector<BatchTranslator> translators_;
 };
-
-std::vector<Ptr<const Vocab>> loadVocabularies(Ptr<Options> options);
 
 } // namespace bergamot
 } // namespace marian

--- a/src/translator/service.h
+++ b/src/translator/service.h
@@ -32,11 +32,18 @@ class Service : public ServiceBase {
 
 public:
   explicit Service(Ptr<Options> options);
-  void enqueue() override;
+  // Implements enqueue and top through blocking methods.
   void stop() override;
   ~Service();
 
 private:
+  void enqueue() override;
+
+  // In addition to the common members (text_processor, requestId, vocabs_,
+  // batcher) extends with a producer-consumer queue, vector of translator
+  // instances owned by service each listening to the pcqueue in separate
+  // threads.
+
   size_t numWorkers_;      // ORDER DEPENDENCY
   PCQueue<Batch> pcqueue_; // ORDER DEPENDENCY
   std::vector<std::thread> workers_;

--- a/src/translator/service_base.cpp
+++ b/src/translator/service_base.cpp
@@ -26,7 +26,9 @@ std::future<Response> ServiceBase::translate(std::string &&input) {
 
 NonThreadedService::NonThreadedService(Ptr<Options> options)
     : ServiceBase(options),
-      translator_(DeviceId(0, DeviceType::cpu), vocabs_, options) {}
+      translator_(DeviceId(0, DeviceType::cpu), vocabs_, options) {
+  translator_.initialize();
+}
 
 void NonThreadedService::enqueue() {
   // Queue single-threaded

--- a/src/translator/service_base.cpp
+++ b/src/translator/service_base.cpp
@@ -1,0 +1,40 @@
+#include "service_base.h"
+
+namespace marian {
+namespace bergamot {
+
+ServiceBase::ServiceBase(Ptr<Options> options)
+    : requestId_(0), vocabs_(std::move(loadVocabularies(options))),
+      text_processor_(vocabs_, options), batcher_(options) {}
+
+std::future<Response> ServiceBase::translate(std::string &&input) {
+  Segments segments;
+  SentenceRanges sourceRanges;
+  text_processor_.process(input, segments, sourceRanges);
+
+  std::promise<Response> responsePromise;
+  auto future = responsePromise.get_future();
+
+  Ptr<Request> request = New<Request>(
+      requestId_++, /* lineNumberBegin = */ 0, vocabs_, std::move(input),
+      std::move(segments), std::move(sourceRanges), std::move(responsePromise));
+
+  batcher_.addWholeRequest(request);
+  enqueue();
+  return future;
+}
+
+NonThreadedService::NonThreadedService(Ptr<Options> options)
+    : ServiceBase(options),
+      translator_(DeviceId(0, DeviceType::cpu), vocabs_, options) {}
+
+void NonThreadedService::enqueue() {
+  // Queue single-threaded
+  Batch batch;
+  while (batcher_ >> batch) {
+    translator_.translate(batch);
+  }
+}
+
+} // namespace bergamot
+} // namespace marian

--- a/src/translator/service_base.h
+++ b/src/translator/service_base.h
@@ -1,0 +1,50 @@
+#ifndef SRC_BERGAMOT_SUBSTANDARD_SERVICE_H_
+#define SRC_BERGAMOT_SUBSTANDARD_SERVICE_H_
+#include "batch_translator.h"
+#include "batcher.h"
+#include "data/types.h"
+#include "response.h"
+#include "text_processor.h"
+
+#include <queue>
+#include <vector>
+
+namespace marian {
+namespace bergamot {
+
+class ServiceBase {
+public:
+  explicit ServiceBase(Ptr<Options> options);
+  std::future<Response> translateWithCopy(std::string input) {
+    return translate(std::move(input));
+  };
+
+  std::future<Response> translate(std::string &&input);
+  Ptr<Vocab const> sourceVocab() const { return vocabs_.front(); }
+  Ptr<Vocab const> targetVocab() const { return vocabs_.back(); }
+  virtual void enqueue() = 0;
+  virtual void stop() = 0;
+
+protected:
+  size_t requestId_;
+  std::vector<Ptr<Vocab const>> vocabs_; // ORDER DEPENDENCY
+  TextProcessor text_processor_;         // ORDER DEPENDENCY
+  Batcher batcher_;
+};
+
+class NonThreadedService : public ServiceBase {
+public:
+  explicit NonThreadedService(Ptr<Options> options);
+  void enqueue();
+  void stop() override{};
+
+private:
+  BatchTranslator translator_;
+};
+
+std::vector<Ptr<const Vocab>> loadVocabularies(Ptr<Options> options);
+
+} // namespace bergamot
+} // namespace marian
+
+#endif // SRC_BERGAMOT_SUBSTANDARD_SERVICE_H_

--- a/src/translator/service_base.h
+++ b/src/translator/service_base.h
@@ -35,7 +35,7 @@ protected:
 class NonThreadedService : public ServiceBase {
 public:
   explicit NonThreadedService(Ptr<Options> options);
-  void enqueue();
+  void enqueue() override;
   void stop() override{};
 
 private:

--- a/src/translator/service_base.h
+++ b/src/translator/service_base.h
@@ -1,5 +1,5 @@
-#ifndef SRC_BERGAMOT_SUBSTANDARD_SERVICE_H_
-#define SRC_BERGAMOT_SUBSTANDARD_SERVICE_H_
+#ifndef SRC_BERGAMOT_SERVICE_BASE_H_
+#define SRC_BERGAMOT_SERVICE_BASE_H_
 #include "batch_translator.h"
 #include "batcher.h"
 #include "data/types.h"
@@ -42,9 +42,26 @@ private:
   BatchTranslator translator_;
 };
 
-std::vector<Ptr<const Vocab>> loadVocabularies(Ptr<Options> options);
+// Internal function nobody used, only within service.
+inline std::vector<Ptr<const Vocab>> loadVocabularies(Ptr<Options> options) {
+  // @TODO: parallelize vocab loading for faster startup
+  auto vfiles = options->get<std::vector<std::string>>("vocabs");
+  // with the current setup, we need at least two vocabs: src and trg
+  ABORT_IF(vfiles.size() < 2, "Insufficient number of vocabularies.");
+  std::vector<Ptr<Vocab const>> vocabs(vfiles.size());
+  std::unordered_map<std::string, Ptr<Vocab>> vmap;
+  for (size_t i = 0; i < vocabs.size(); ++i) {
+    auto m = vmap.emplace(std::make_pair(vfiles[i], Ptr<Vocab>()));
+    if (m.second) { // new: load the vocab
+      m.first->second = New<Vocab>(options, i);
+      m.first->second->load(vfiles[i]);
+    }
+    vocabs[i] = m.first->second;
+  }
+  return vocabs;
+}
 
 } // namespace bergamot
 } // namespace marian
 
-#endif // SRC_BERGAMOT_SUBSTANDARD_SERVICE_H_
+#endif // SRC_BERGAMOT_SERVICE_BASE_H_

--- a/src/translator/service_base.h
+++ b/src/translator/service_base.h
@@ -11,21 +11,31 @@
 
 namespace marian {
 namespace bergamot {
+// This file describes the base class ServiceBase, and a non-threaded subclass
+// implementing translation functionality called NonThreadedService.
 
 class ServiceBase {
 public:
   explicit ServiceBase(Ptr<Options> options);
-  std::future<Response> translateWithCopy(std::string input) {
-    return translate(std::move(input));
-  };
 
+  // Transfers ownership of input string to Service, returns a future containing
+  // an object which provides access to translations, other features like
+  // sentencemappings and (tentatively) alignments.
   std::future<Response> translate(std::string &&input);
+
+  // Convenience accessor methods to extract these vocabulary outside service.
+  // e.g: For use in decoding histories for marian-decoder replacement.
   Ptr<Vocab const> sourceVocab() const { return vocabs_.front(); }
   Ptr<Vocab const> targetVocab() const { return vocabs_.back(); }
-  virtual void enqueue() = 0;
+
+  // Wraps up any thread related destruction code.
   virtual void stop() = 0;
 
 protected:
+  // Enqueue queues a request for translation, this can be synchronous, blocking
+  // or asynchronous and queued in the background.
+  virtual void enqueue() = 0;
+
   size_t requestId_;
   std::vector<Ptr<Vocab const>> vocabs_; // ORDER DEPENDENCY
   TextProcessor text_processor_;         // ORDER DEPENDENCY
@@ -35,14 +45,17 @@ protected:
 class NonThreadedService : public ServiceBase {
 public:
   explicit NonThreadedService(Ptr<Options> options);
-  void enqueue() override;
   void stop() override{};
 
 private:
+  // NonThreaded service overrides unimplemented functions in base-class using
+  // blocking mechanisms.
+  void enqueue() override;
+  // There's a single translator, launched as part of the main process.
   BatchTranslator translator_;
 };
 
-// Internal function nobody used, only within service.
+// Used across Services
 inline std::vector<Ptr<const Vocab>> loadVocabularies(Ptr<Options> options) {
   // @TODO: parallelize vocab loading for faster startup
   auto vfiles = options->get<std::vector<std::string>>("vocabs");


### PR DESCRIPTION
* Adds a permanent _ci-sandbox_ branch to all `.yml` files to force push and test in case CI breaks. I vote to keep this in source.
* Rewrites NonThreaded and threaded implementations with minimal `ifdefs`.
* Should fix #41: That this doesn't happen in the concurrent queuing development branch should point to something with the threading mechanism with ifdefs faults. Inspection through gdb found several places where threads were crashing, initialized with arbitrary values. These potentially leads to issues with the shared_ptrs as well. The applied solution is to not have threads at all in the non-threaded code and have legit (properly initialized) threads in the multithreaded code. The shared parts are now redirected to a base class (ServiceBase). 

* bergamot-translator-app talks only to NonThreadedService. This means the `--cpu-threads` option is now moot. 
* Anything which wouldn't use multiple threads are disabled during WASM builds - service-cli, marian-decoder-new etc. 