### PR TITLE
Patch WASM artifacts to run optimized (wormhole enabled) inference

### DIFF
--- a/.github/workflows/macos-custom-marian-wasm.yml
+++ b/.github/workflows/macos-custom-marian-wasm.yml
@@ -33,6 +33,13 @@ jobs:
         working-directory: build-wasm
         run: emmake make -j2
 
+      - name: Instantiate simd wormhole
+        working-directory: build-wasm
+        run: |
+          sed -i.bak 's/var result = WebAssembly.instantiateStreaming(response, info);/var result = WebAssembly.instantiateStreaming(response, info, {simdWormhole:true});/g' wasm/bergamot-translator-worker.js
+          sed -i.bak 's/return WebAssembly.instantiate(binary, info);/return WebAssembly.instantiate(binary, info, {simdWormhole:true});/g' wasm/bergamot-translator-worker.js
+          sed -i.bak 's/var module = new WebAssembly.Module(bytes);/var module = new WebAssembly.Module(bytes, {simdWormhole:true});/g' wasm/bergamot-translator-worker.js
+
       - name: Check artifacts
         working-directory: build-wasm
         run: |

--- a/.github/workflows/macos-custom-marian-wasm.yml
+++ b/.github/workflows/macos-custom-marian-wasm.yml
@@ -35,10 +35,7 @@ jobs:
 
       - name: Instantiate simd wormhole
         working-directory: build-wasm
-        run: |
-          sed -i.bak 's/var result = WebAssembly.instantiateStreaming(response, info);/var result = WebAssembly.instantiateStreaming(response, info, {simdWormhole:true});/g' wasm/bergamot-translator-worker.js
-          sed -i.bak 's/return WebAssembly.instantiate(binary, info);/return WebAssembly.instantiate(binary, info, {simdWormhole:true});/g' wasm/bergamot-translator-worker.js
-          sed -i.bak 's/var module = new WebAssembly.Module(bytes);/var module = new WebAssembly.Module(bytes, {simdWormhole:true});/g' wasm/bergamot-translator-worker.js
+        run: bash ../wasm/patch-artifacts-enable-wormhole.sh
 
       - name: Check artifacts
         working-directory: build-wasm

--- a/README.md
+++ b/README.md
@@ -75,17 +75,16 @@ Bergamot translator provides a unified API for ([Marian NMT](https://marian-nmt.
             emmake make -j
             ```
 
+        The wasm artifacts (.js and .wasm files) will be available in `wasm` folder of build directory ("build-wasm" in this case).
+
     3. Enable SIMD Wormhole via Wasm instantiation API in generated artifacts
+        ```bash
+        bash ../wasm/patch-artifacts-enable-wormhole.sh
         ```
-        sed -i.bak 's/var result = WebAssembly.instantiateStreaming(response, info);/var result = WebAssembly.instantiateStreaming(response, info, {simdWormhole:true});/g' wasm/bergamot-translator-worker.js
-        sed -i.bak 's/return WebAssembly.instantiate(binary, info);/return WebAssembly.instantiate(binary, info, {simdWormhole:true});/g' wasm/bergamot-translator-worker.js
-        sed -i.bak 's/var module = new WebAssembly.Module(bytes);/var module = new WebAssembly.Module(bytes, {simdWormhole:true});/g' wasm/bergamot-translator-worker.js
-        ```
-    The artefacts (.js and .wasm files) will be available in `wasm` folder of build directory ("build-wasm" in this case).
 
 #### Recompiling
-As long as you don't update any submodule, just follow steps in `4.ii` to recompile.\
-If you update a submodule, execute following command before executing steps in `4.ii` to recompile.
+As long as you don't update any submodule, just follow steps in `4.ii` and `4.iii` to recompile.\
+If you update a submodule, execute following command before executing steps in `4.ii` and `4.iii` to recompile.
 ```bash
 git submodule update --init --recursive
 ```

--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ Bergamot translator provides a unified API for ([Marian NMT](https://marian-nmt.
             emmake make -j
             ```
 
+    3. Enable SIMD Wormhole via Wasm instantiation API in generated artifacts
+        ```
+        sed -i.bak 's/var result = WebAssembly.instantiateStreaming(response, info);/var result = WebAssembly.instantiateStreaming(response, info, {simdWormhole:true});/g' wasm/bergamot-translator-worker.js
+        sed -i.bak 's/return WebAssembly.instantiate(binary, info);/return WebAssembly.instantiate(binary, info, {simdWormhole:true});/g' wasm/bergamot-translator-worker.js
+        sed -i.bak 's/var module = new WebAssembly.Module(bytes);/var module = new WebAssembly.Module(bytes, {simdWormhole:true});/g' wasm/bergamot-translator-worker.js
+        ```
     The artefacts (.js and .wasm files) will be available in `wasm` folder of build directory ("build-wasm" in this case).
 
 #### Recompiling

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Bergamot translator provides a unified API for ([Marian NMT](https://marian-nmt.
     ```bash
     mkdir models
     git clone https://github.com/mozilla-applied-ml/bergamot-models
-    cp -rf bergamot-models/* models
+    cp -rf bergamot-models/prod/* models
     gunzip models/*/*
     ```
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Bergamot translator provides a unified API for ([Marian NMT](https://marian-nmt.
     If you want to package bergamot project specific models, please follow these instructions:
     ```bash
     mkdir models
-    git clone https://github.com/mozilla-applied-ml/bergamot-models
+    git clone --depth 1 --branch main --single-branch https://github.com/mozilla-applied-ml/bergamot-models
     cp -rf bergamot-models/prod/* models
     gunzip models/*/*
     ```

--- a/wasm/patch-artifacts-enable-wormhole.sh
+++ b/wasm/patch-artifacts-enable-wormhole.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "Patching wasm artifacts to enable wormhole via APIs that compile and instantiate wasm module"
+sed -i.bak 's/var result = WebAssembly.instantiateStreaming(response, info);/var result = WebAssembly.instantiateStreaming(response, info, {simdWormhole:true});/g' wasm/bergamot-translator-worker.js
+sed -i.bak 's/return WebAssembly.instantiate(binary, info);/return WebAssembly.instantiate(binary, info, {simdWormhole:true});/g' wasm/bergamot-translator-worker.js
+sed -i.bak 's/var module = new WebAssembly.Module(bytes);/var module = new WebAssembly.Module(bytes, {simdWormhole:true});/g' wasm/bergamot-translator-worker.js
+echo "Done"

--- a/wasm/test_page/bergamot.html
+++ b/wasm/test_page/bergamot.html
@@ -32,6 +32,9 @@
     <label>Choose the model to use</label>
     <input type="radio" name="modellang" value="enes"/><label>English to Spanish</label>
     <input type="radio" name="modellang" value="esen" checked/><label>Spanish to English</label>
+    <input type="radio" name="modellang" value="eten" checked/><label>Estonian to English</label>
+    <input type="radio" name="modellang" value="enet" checked/><label>English to Estonian</label>
+    <input type="radio" name="modellang" value="ende" checked/><label>English to German</label>
     <input type="button" id="load" value="Load Model"/>
 </div>
 
@@ -70,7 +73,7 @@ En consecuencia, durante el año 2011 se introdujeron 180 proyectos de ley que r
     // Set the Model Configuration as YAML formatted string.
     // For available configuration options, please check: https://marian-nmt.github.io/docs/cmd/marian-decoder/
     const modelConfig = `models:
-  - /${languagePair}/model.${languagePair}.intgemm.bin
+  - /${languagePair}/model.${languagePair}.intgemm.alphas.bin
 vocabs:
   - /${vocabLanguagePair}/vocab.${vocabLanguagePair}.spm
   - /${vocabLanguagePair}/vocab.${vocabLanguagePair}.spm

--- a/wasm/test_page/bergamot.html
+++ b/wasm/test_page/bergamot.html
@@ -70,7 +70,7 @@ En consecuencia, durante el año 2011 se introdujeron 180 proyectos de ley que r
     // Set the Model Configuration as YAML formatted string.
     // For available configuration options, please check: https://marian-nmt.github.io/docs/cmd/marian-decoder/
     const modelConfig = `models:
-  - /${languagePair}/model.${languagePair}.npz
+  - /${languagePair}/model.${languagePair}.intgemm.bin
 vocabs:
   - /${vocabLanguagePair}/vocab.${vocabLanguagePair}.spm
   - /${vocabLanguagePair}/vocab.${vocabLanguagePair}.spm

--- a/wasm/test_page/start_server.sh
+++ b/wasm/test_page/start_server.sh
@@ -4,13 +4,6 @@ cp ../../build-wasm/wasm/bergamot-translator-worker.data .
 cp ../../build-wasm/wasm/bergamot-translator-worker.js .
 cp ../../build-wasm/wasm/bergamot-translator-worker.wasm .
 cp ../../build-wasm/wasm/bergamot-translator-worker.worker.js .
-echo "Done----"
-
-echo "Start: Enabling wormhole via APIs that compile and instantiate wasm module-------"
-sed -i.bak 's/var result = WebAssembly.instantiateStreaming(response, info);/var result = WebAssembly.instantiateStreaming(response, info, {simdWormhole:true});/g' bergamot-translator-worker.js
-sed -i.bak 's/return WebAssembly.instantiate(binary, info);/return WebAssembly.instantiate(binary, info, {simdWormhole:true});/g' bergamot-translator-worker.js
-sed -i.bak 's/var module = new WebAssembly.Module(bytes);/var module = new WebAssembly.Module(bytes, {simdWormhole:true});/g' bergamot-translator-worker.js
-echo "Done: Enabling wormhole via APIs that compile and instantiate wasm module--------"
 
 npm install
 echo "Start httpserver"

--- a/wasm/test_page/start_server.sh
+++ b/wasm/test_page/start_server.sh
@@ -1,8 +1,17 @@
 #!/bin/bash
-
+echo "Start: Copying artifacts in local folder------"
 cp ../../build-wasm/wasm/bergamot-translator-worker.data .
 cp ../../build-wasm/wasm/bergamot-translator-worker.js .
 cp ../../build-wasm/wasm/bergamot-translator-worker.wasm .
 cp ../../build-wasm/wasm/bergamot-translator-worker.worker.js .
+echo "Done----"
+
+echo "Start: Enabling wormhole via APIs that compile and instantiate wasm module-------"
+sed -i.bak 's/var result = WebAssembly.instantiateStreaming(response, info);/var result = WebAssembly.instantiateStreaming(response, info, {simdWormhole:true});/g' bergamot-translator-worker.js
+sed -i.bak 's/return WebAssembly.instantiate(binary, info);/return WebAssembly.instantiate(binary, info, {simdWormhole:true});/g' bergamot-translator-worker.js
+sed -i.bak 's/var module = new WebAssembly.Module(bytes);/var module = new WebAssembly.Module(bytes, {simdWormhole:true});/g' bergamot-translator-worker.js
+echo "Done: Enabling wormhole via APIs that compile and instantiate wasm module--------"
+
 npm install
+echo "Start httpserver"
 node bergamot-httpserver.js


### PR DESCRIPTION
This fixes https://github.com/browsermt/bergamot-translator/issues/49

- Patches wasm artifacts to enable wormhole so that optimized inference can happen
- Updated README
- Updated corresponding github workflow