### PR TITLE
Change bergamot app to process stdin texts

### DIFF
--- a/app/bergamot-translator-app.cpp
+++ b/app/bergamot-translator-app.cpp
@@ -1,11 +1,13 @@
 /*
  * main.cpp
  *
- * An example application to demonstrate the use of Bergamot translator.
+ * An application which accepts line separated texts in stdin and returns translated ones in stdout.
+ * It is convenient for batch processing and can be used with tools like SacreBLEU.
  *
  */
 
 #include <iostream>
+#include <string>
 
 #include "TranslationModel.h"
 #include "translator/parser.h"
@@ -23,22 +25,10 @@ int main(int argc, char **argv) {
 
   TranslationRequest translationRequest;
   std::vector<std::string> texts;
-  texts.emplace_back(
-      "The Bergamot project will add and improve client-side machine "
-      "translation in a web browser.  Unlike current cloud-based "
-      "options, running directly on users’ machines empowers citizens to "
-      "preserve their privacy and increases the uptake of language "
-      "technologies in Europe in various sectors that require "
-      "confidentiality.");
-  texts.emplace_back(
-      "Free software integrated with an open-source web "
-      "browser, such as Mozilla Firefox, will enable bottom-up adoption "
-      "by non-experts, resulting in cost savings for private and public "
-      "sector users who would otherwise procure translation or operate "
-      "monolingually.  Bergamot is a consortium coordinated by the "
-      "University of Edinburgh with partners Charles University in "
-      "Prague, the University of Sheffield, University of Tartu, and "
-      "Mozilla.");
+
+  for (std::string line; std::getline(std::cin, line);) {
+        texts.emplace_back(line);
+  }
 
   auto results = model->translate(std::move(texts), translationRequest);
 
@@ -46,17 +36,7 @@ int main(int argc, char **argv) {
   //std::vector<TranslationResult> results = futureResults.get();
 
   for (auto &result : results) {
-    std::cout << "[original]: " << result.getOriginalText() << std::endl;
-    std::cout << "[translated]: " << result.getTranslatedText() << std::endl;
-    auto mappings = result.getSentenceMappings();
-    for (auto &p : mappings) {
-      std::string_view src = p.first;
-      std::string_view tgt = p.second;
-
-      std::cout << " [src Sentence]: " << src << std::endl;
-      std::cout << " [tgt Sentence]: " << tgt << std::endl;
-    }
-    std::cout << std::endl;
+    std::cout << result.getTranslatedText() << std::endl;
   }
 
   return 0;


### PR DESCRIPTION
I need a simple app for evaluation that should be able to accept newline-separated texts in stdin, translate them separately and output results to stdout. Basically the same behavior as `marian-decoder`. The motivation to use `bergamot-translator` and high-level API is to be as close to the production setup in Firefox as possible.

@abhi-agg suggested fixing `bergamot-translator-app` to support this functionality.