### PR TITLE
Explictly install gcc version and use 8

### DIFF
--- a/.github/workflows/native-full_marian-ubuntu.yml
+++ b/.github/workflows/native-full_marian-ubuntu.yml
@@ -15,7 +15,7 @@ jobs:
           - name: "Ubuntu CPU-only"
             os: ubuntu-latest
             cuda: ""
-            gcc: 7
+            gcc: 8
             cpu: true
             gpu: false
           # GPU Builds are commented out, for bergamot-translator CI runs.
@@ -62,7 +62,7 @@ jobs:
     # No need to install libprotobuf{17,10,9v5} on Ubuntu {20,18,16}.04 because
     # it is installed together with libprotobuf-dev
     - name: Install dependencies
-      run: sudo apt-get update && sudo apt-get install -y libgoogle-perftools-dev libprotobuf-dev protobuf-compiler libboost-all-dev
+      run: sudo apt-get update && sudo apt-get install -y libgoogle-perftools-dev libprotobuf-dev protobuf-compiler libboost-all-dev g++-8
 
     # https://software.intel.com/content/www/us/en/develop/articles/installing-intel-free-libs-and-python-apt-repo.html
     - name: Install MKL

--- a/.github/workflows/native-full_marian-ubuntu.yml
+++ b/.github/workflows/native-full_marian-ubuntu.yml
@@ -2,9 +2,9 @@ name: Native (Full Marian) Ubuntu
 
 on:
   push:
-    branches: [ main, ci-sandbox ]
+    branches: [ main, ci-test ]
   pull_request:
-    branches: [ main, ci-sandbox ]
+    branches: [ main, ci-test ]
 
 jobs:
   build-ubuntu:


### PR DESCRIPTION
CI is failing due to some change at github https://github.com/browsermt/bergamot-translator/pull/69/checks?check_run_id=2245404337