### PR TITLE
Make AlignedMemory the means of passing in memory

### DIFF
--- a/app/bergamot-translator-app-bytearray.cpp
+++ b/app/bergamot-translator-app-bytearray.cpp
@@ -19,11 +19,8 @@ int main(int argc, char **argv) {
   auto options = configParser.parseOptions(argc, argv, true);
   std::string config = options->asYamlString();
 
-  // Prepare model byte array
-  marian::bergamot::AlignedMemory modelBytes = marian::bergamot::getModelMemoryFromConfig(options);
-
   // Route the config string to construct marian model through TranslationModel
-  TranslationModel model(config, modelBytes.begin());
+  TranslationModel model(config, marian::bergamot::getModelMemoryFromConfig(options));
 
   TranslationRequest translationRequest;
   std::vector<std::string> texts;

--- a/src/TranslationModel.h
+++ b/src/TranslationModel.h
@@ -17,6 +17,7 @@
 // All local project includes
 #include "TranslationRequest.h"
 #include "TranslationResult.h"
+#include "translator/definitions.h"
 #include "translator/service.h"
 
 /* A Translation model that translates a plain (without any markups and emojis)
@@ -34,7 +35,8 @@ public:
    * the bytes of a model.bin.
    */
   TranslationModel(const std::string &config,
-                   const void *model_memory = nullptr);
+                   marian::bergamot::AlignedMemory modelMemory = marian::bergamot::AlignedMemory(),
+                   marian::bergamot::AlignedMemory shortlistMemory = marian::bergamot::AlignedMemory());
 
   ~TranslationModel();
 

--- a/src/translator/TranslationModel.cpp
+++ b/src/translator/TranslationModel.cpp
@@ -12,8 +12,9 @@
 #include "translator/service.h"
 
 TranslationModel::TranslationModel(const std::string &config,
-                                   const void *model_memory)
-    : service_(config, model_memory) {}
+                                   marian::bergamot::AlignedMemory model_memory,
+                                   marian::bergamot::AlignedMemory lexical_memory)
+    : service_(config, std::move(model_memory), std::move(lexical_memory)) {}
 
 TranslationModel::~TranslationModel() {}
 


### PR DESCRIPTION
Removes hack that shouldn't have been allowed in from #69 by propagating AlignedVector.  