### PR TITLE
Windows workflows and mac framework accelerate draft

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -39,8 +39,8 @@ jobs:
     - name: Prepare vcpkg
       uses: lukka/run-vcpkg@v4
       with:
-        vcpkgArguments: protobuf pcre2 #@TODO separate versions?
-        #vcpkgGitCommitId: 6185aa76504a5025f36754324abf307cc776f3da
+        vcpkgArguments: protobuf pcre2
+        vcpkgGitCommitId: 6185aa76504a5025f36754324abf307cc776f3da a4eca5fabc1743e309e75736c6d8a2420f48193d
         vcpkgDirectory: ${{ github.workspace }}/vcpkg/
         vcpkgTriplet: x64-windows-static
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -40,7 +40,7 @@ jobs:
       uses: lukka/run-vcpkg@v4
       with:
         vcpkgArguments: protobuf pcre2
-        vcpkgGitCommitId: 6185aa76504a5025f36754324abf307cc776f3da a4eca5fabc1743e309e75736c6d8a2420f48193d
+        vcpkgGitCommitId: 6185aa76504a5025f36754324abf307cc776f3da 
         vcpkgDirectory: ${{ github.workspace }}/vcpkg/
         vcpkgTriplet: x64-windows-static
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Prepare vcpkg
       uses: lukka/run-vcpkg@v4
       with:
-        vcpkgArguments: protobuf pcre2
+        vcpkgArguments: protobuf pcre2 #@TODO separate versions?
         #vcpkgGitCommitId: 6185aa76504a5025f36754324abf307cc776f3da
         vcpkgDirectory: ${{ github.workspace }}/vcpkg/
         vcpkgTriplet: x64-windows-static

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,12 +17,6 @@ jobs:
           # Windows CPU-only build
           - name: "Windows CPU-only"
             cuda: ""
-            gpu: false
-          # GPU Builds are commented out, for bergamot-translator CI runs.
-          # Windows CPU+GPU build
-          # - name: "Windows CPU+CUDA"
-          #   cuda: "10.2"
-          #   gpu: true
 
     runs-on: windows-2019
     name: ${{ matrix.name }}
@@ -42,89 +36,31 @@ jobs:
         echo "MKLROOT=${{ github.workspace }}\mkl" | Out-File -FilePath $env:GITHUB_ENV  -Encoding utf8 -Append
       shell: powershell
 
-    - name: Install CUDA
-      run: |
-        .\3rd_party\marian-dev\scripts\ci\install_cuda_windows.ps1 "10.2"
-        # Set CUDA_PATH environment variable so that CMake can find CUDA
-        echo "CUDA_PATH=$env:CUDA_PATH" | Out-File -FilePath $env:GITHUB_ENV  -Encoding utf8 -Append
-        echo "$env:CUDA_PATH/bin"       | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      shell: powershell
-      if: matrix.gpu == true
-
     - name: Prepare vcpkg
       uses: lukka/run-vcpkg@v4
       with:
-        vcpkgArguments: protobuf
-        vcpkgGitCommitId: 6185aa76504a5025f36754324abf307cc776f3da
+        vcpkgArguments: protobuf pcre2
+        #vcpkgGitCommitId: 6185aa76504a5025f36754324abf307cc776f3da
         vcpkgDirectory: ${{ github.workspace }}/vcpkg/
         vcpkgTriplet: x64-windows-static
 
-    # Windows CUDA builds use USE_NCCL=off due to compilation errors.
+    # Windows CPU only minimal build
     - name: Build Debug
       uses: lukka/run-cmake@v3
       with:
         buildDirectory: ${{ github.workspace }}/build/Debug
         cmakeAppendedArgs: '-G Ninja
           -DCMAKE_BUILD_TYPE="Debug"
-          -DOPENSSL_USE_STATIC_LIBS="TRUE"
-          -DOPENSSL_MSVC_STATIC_RT="TRUE"
-          -DCOMPILE_CPU="TRUE"
-          -DCOMPILE_CUDA="${{ matrix.gpu }}"
-          -DCOMPILE_SERVER="FALSE"
-          -DCOMPILE_TESTS="TRUE"
-          -DUSE_FBGEMM="TRUE"
-          -DUSE_MPI="FALSE"
-          -DUSE_NCCL="FALSE"
-          -DUSE_SENTENCEPIECE="TRUE"
-          -DUSE_STATIC_LIBS="TRUE"'
-        cmakeListsOrSettingsJson: CMakeListsTxtAdvanced
-        cmakeListsTxtPath: ${{ github.workspace }}/CMakeLists.txt
-        useVcpkgToolchainFile: true
-      # Building in Debug is sufficient for the all-in CPU+GPU compilation;
-      # its main purpose is to detect warnings that the Release build is not
-      # able to find sometimes.
-      if: matrix.gpu == true
-
-    # Windows CUDA builds use USE_NCCL=off due to compilation errors
-    # Boost is pre-installed on Azure/GitHub-hosted Windows runners
-    # https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md#boost
-    # (not used yet)
-    - name: Build Release
-      uses: lukka/run-cmake@v3
-      with:
-        buildDirectory: ${{ github.workspace }}/build/
-        cmakeAppendedArgs: '-G Ninja
-          -DBOOST_ROOT="$(BOOST_ROOT_1_72_0)"
-          -DBOOST_INCLUDEDIR="$(BOOST_ROOT_1_72_0)/include"
-          -DBOOST_LIBRARYDIR="$(BOOST_ROOT_1_72_0)/lib"
-          -DCMAKE_BUILD_TYPE="Release"
-          -DOPENSSL_USE_STATIC_LIBS="TRUE"
-          -DOPENSSL_MSVC_STATIC_RT="TRUE"
-          -DCOMPILE_CPU="TRUE"
-          -DCOMPILE_CUDA="${{ matrix.gpu }}"
-          -DCOMPILE_SERVER="FALSE"
-          -DCOMPILE_TESTS="TRUE"
-          -DUSE_FBGEMM="TRUE"
-          -DUSE_MPI="FALSE"
-          -DUSE_NCCL="FALSE"
-          -DUSE_SENTENCEPIECE="TRUE"
+          -DUSE_WASM_COMPATIBLE_SOURCE="OFF"
           -DUSE_STATIC_LIBS="TRUE"'
         cmakeListsOrSettingsJson: CMakeListsTxtAdvanced
         cmakeListsTxtPath: ${{ github.workspace }}/CMakeLists.txt
         useVcpkgToolchainFile: true
 
-    # Removing unit-tests, taken care of in browsermt/marian-dev
-    # - name: Run unit tests
-    #   working-directory: build/
-    #   run: ctest
-    #   # Not run in GPU builds because GitHub-hosted VMs do not have GPUs
-    #   if: matrix.gpu == false
 
     - name: Print versions
       working-directory: build/
       run: |
-        .\marian.exe --version
-        .\marian-decoder.exe --version
-        .\marian-scorer.exe --version
+        .\app\bergamot-translator-app.exe --version
         dir *.exe
       shell: cmd


### PR DESCRIPTION
This pull request updates the marian-dev submodule to the latest version of browsermt and restores the windows workflow.

The marian-dev changes allow to use the apple accelerate framework when running on apple machine and allows for compilation with apple clang. I also fixed they way `BLAS_FOUND` was being defined because it was preventing BLAS_FOUND to be set in some rare cases.

Finally, the windows workflow is fixed up, but will fail until some ssplit-cpp changes land. Those will go to a separate pull request, as they involve a few small changes to the CMakeLists.txt.