### PR TITLE
Changed underlying template parameter of AlignedMemory class

### DIFF
--- a/src/translator/definitions.h
+++ b/src/translator/definitions.h
@@ -22,8 +22,8 @@ template <class T, typename... Args> UPtr<T> UNew(Args &&... args) {
 
 template <class T> UPtr<T> UNew(UPtr<T> p) { return UPtr<T>(p); }
 
-/// Shortcut to AlignedVector<const void*> for byte arrays
-typedef AlignedVector<const void*> AlignedMemory;
+/// Shortcut to AlignedVector<char> for byte arrays
+typedef AlignedVector<char> AlignedMemory;
 
 } // namespace bergamot
 } // namespace marian


### PR DESCRIPTION
 - AlignedMemory is AlignedVector<char> now instead of AlignedVector<const void*>
 - This solves the issue of allocating 8x of the actual required memory for
   loading files as bytes
   
This PR fixes https://github.com/browsermt/bergamot-translator/issues/110