### PR TITLE
Control validating the config options via a boolean flag

### DIFF
--- a/src/translator/parser.h
+++ b/src/translator/parser.h
@@ -31,7 +31,7 @@ inline marian::ConfigParser createConfigParser() {
 }
 
 inline std::shared_ptr<marian::Options>
-parseOptions(const std::string &config) {
+parseOptions(const std::string &config, bool validate = true) {
   marian::Options options;
 
   // @TODO(jerinphilip) There's something off here, @XapaJIaMnu suggests
@@ -58,8 +58,11 @@ parseOptions(const std::string &config) {
   options.parse(config);
   YAML::Node configCopy = options.cloneToYamlNode();
 
-  marian::ConfigValidator validator(configCopy);
-  validator.validateOptions(marian::cli::mode::translation);
+  if (validate) {
+    // Perform validation on parsed options only when requested
+    marian::ConfigValidator validator(configCopy);
+    validator.validateOptions(marian::cli::mode::translation);
+  }
 
   return std::make_shared<marian::Options>(options);
 }

--- a/src/translator/service.h
+++ b/src/translator/service.h
@@ -84,7 +84,7 @@ public:
   explicit Service(const std::string &config,
                    AlignedMemory modelMemory = AlignedMemory(),
                    AlignedMemory shortlistMemory = AlignedMemory())
-      : Service(parseOptions(config), std::move(modelMemory),
+      : Service(parseOptions(config, false), std::move(modelMemory),
                 std::move(shortlistMemory)) {}
 
   /// Explicit destructor to clean up after any threads initialized in

--- a/src/translator/service.h
+++ b/src/translator/service.h
@@ -84,7 +84,7 @@ public:
   explicit Service(const std::string &config,
                    AlignedMemory modelMemory = AlignedMemory(),
                    AlignedMemory shortlistMemory = AlignedMemory())
-      : Service(parseOptions(config, false), std::move(modelMemory),
+      : Service(parseOptions(config, /*validate=*/false), std::move(modelMemory),
                 std::move(shortlistMemory)) {}
 
   /// Explicit destructor to clean up after any threads initialized in


### PR DESCRIPTION
 - parseOptions() function now validates the parsed options
   based on the validate argument
 
 The PR fixes https://github.com/browsermt/bergamot-translator/issues/112