### PR TITLE
Improve script to patch wasm artifacts and load EN->DE vocabulary in wasm test

### DIFF
--- a/wasm/patch-artifacts-enable-wormhole.sh
+++ b/wasm/patch-artifacts-enable-wormhole.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "Patching wasm artifacts to enable wormhole via APIs that compile and instantiate wasm module"
-sed -i.bak 's/var result = WebAssembly.instantiateStreaming(response, info);/var result = WebAssembly.instantiateStreaming(response, info, {simdWormhole:true});/g' wasm/bergamot-translator-worker.js
-sed -i.bak 's/return WebAssembly.instantiate(binary, info);/return WebAssembly.instantiate(binary, info, {simdWormhole:true});/g' wasm/bergamot-translator-worker.js
-sed -i.bak 's/var module = new WebAssembly.Module(bytes);/var module = new WebAssembly.Module(bytes, {simdWormhole:true});/g' wasm/bergamot-translator-worker.js
+sed -i.bak 's/WebAssembly.instantiateStreaming[[:space:]]*([[:space:]]*response[[:space:]]*,[[:space:]]*info[[:space:]]*)/WebAssembly.instantiateStreaming(response, info, {simdWormhole:true})/g' wasm/bergamot-translator-worker.js
+sed -i.bak 's/WebAssembly.instantiate[[:space:]]*([[:space:]]*binary[[:space:]]*,[[:space:]]*info[[:space:]]*)/WebAssembly.instantiate(binary, info, {simdWormhole:true})/g' wasm/bergamot-translator-worker.js
+sed -i.bak 's/WebAssembly.Module[[:space:]]*([[:space:]]*bytes[[:space:]]*)/WebAssembly.Module(bytes, {simdWormhole:true})/g' wasm/bergamot-translator-worker.js
 echo "Done"

--- a/wasm/test_page/bergamot.html
+++ b/wasm/test_page/bergamot.html
@@ -93,8 +93,8 @@ En consecuencia, durante el año 2011 se introdujeron 180 proyectos de ley que r
     /*const modelConfig = `models:
   - /${languagePair}/model.${languagePair}.intgemm.alphas.bin
 vocabs:
-  - /${vocabLanguagePair}/vocab.${vocabLanguagePair}.spm
-  - /${vocabLanguagePair}/vocab.${vocabLanguagePair}.spm
+  - /${languagePair}/vocab.${vocabLanguagePair}.spm
+  - /${languagePair}/vocab.${vocabLanguagePair}.spm
 beam-size: 1
 normalize: 1.0
 word-penalty: 0
@@ -114,8 +114,8 @@ shortlist:
 */
 
 const modelConfigWithoutModelAndShortList = `vocabs:
-  - /${vocabLanguagePair}/vocab.${vocabLanguagePair}.spm
-  - /${vocabLanguagePair}/vocab.${vocabLanguagePair}.spm
+  - /${languagePair}/vocab.${vocabLanguagePair}.spm
+  - /${languagePair}/vocab.${vocabLanguagePair}.spm
 beam-size: 1
 normalize: 1.0
 word-penalty: 0


### PR DESCRIPTION
The PR:
- Improves the script that patches wasm artifacts to enable simd wormhole
    - Introduces a more robust pattern matching of wasm instantiation API in the generated wasm artifacts
    - This fixes the issue observed in https://github.com/browsermt/bergamot-translator/pull/87#discussion_r624071379
- Fixes wasm test page for loading EN->DE vocabulary properly
    - With latest [bergamot-models](https://github.com/mozilla-applied-ml/bergamot-models/tree/main/prod), it wasn't working for EN->DE
    - Now it works