### PR TITLE
Improved wasm scripts and README

### DIFF
--- a/.github/workflows/wasm-custom_marian-mac.yml
+++ b/.github/workflows/wasm-custom_marian-mac.yml
@@ -40,9 +40,8 @@ jobs:
       - name: Check artifacts
         working-directory: build-wasm
         run: |
-          export WASM_ARTIFACTS_DIR=wasm
-          ls -all ${WASM_ARTIFACTS_DIR}
-          if ls ${WASM_ARTIFACTS_DIR}/*.wasm &>/dev/null && ls ${WASM_ARTIFACTS_DIR}/*.js &>/dev/null
+          ls -all bergamot*
+          if ls bergamot*.wasm &>/dev/null && ls bergamot*.js &>/dev/null
           then
             echo "Artifacts Successfully Generated"
           else

--- a/.github/workflows/wasm-custom_marian-ubuntu.yml
+++ b/.github/workflows/wasm-custom_marian-ubuntu.yml
@@ -40,9 +40,8 @@ jobs:
       - name: Check artifacts
         working-directory: build-wasm
         run: |
-          export WASM_ARTIFACTS_DIR=wasm
-          ls -all ${WASM_ARTIFACTS_DIR}
-          if ls ${WASM_ARTIFACTS_DIR}/*.wasm &>/dev/null && ls ${WASM_ARTIFACTS_DIR}/*.js &>/dev/null
+          ls -all bergamot*
+          if ls bergamot*.wasm &>/dev/null && ls bergamot*.js &>/dev/null
           then
             echo "Artifacts Successfully Generated"
           else

--- a/README.md
+++ b/README.md
@@ -36,19 +36,18 @@ Bergamot translator provides a unified API for ([Marian NMT](https://marian-nmt.
     cd bergamot-translator
     ```
 
-3. Download files (only required if you want to package files in wasm binary)
+3. Download files (only required if you want to perform inference using build artifacts)
 
-    This step is only required if you want to package files (e.g. models, vocabularies etc.)
-    into wasm binary. If you don't then just skip this step.
+    It packages the vocabulary files into wasm binary, which is required only if you want to perform inference.
+    The compilation commands will preload these files in Emscripten’s virtual file system.
 
-    The build preloads the files in Emscripten’s virtual file system.
-
-    If you want to package bergamot project specific models, please follow these instructions:
+    If you want to package bergamot project specific files, please follow these instructions:
     ```bash
-    mkdir models
     git clone --depth 1 --branch main --single-branch https://github.com/mozilla-applied-ml/bergamot-models
+    mkdir models
     cp -rf bergamot-models/prod/* models
     gunzip models/*/*
+    find models \( -type f -name "model*" -or -type f -name "lex*" \) -delete
     ```
 
 4. Compile
@@ -59,14 +58,14 @@ Bergamot translator provides a unified API for ([Marian NMT](https://marian-nmt.
         ```
 
     2. Compile the artefacts
-        * If you want to package files into wasm binary then execute following commands (Replace `FILES_TO_PACKAGE` with the path of the
-        directory containing the files to be packaged in wasm binary)
+        * If you want to package files into wasm binary then execute following commands (Replace `FILES_TO_PACKAGE` with the
+        directory containing all the files to be packaged)
 
             ```bash
             emcmake cmake -DCOMPILE_WASM=on -DPACKAGE_DIR=FILES_TO_PACKAGE ../
             emmake make -j
             ```
-            e.g. If you want to package bergamot project specific models (downloaded using step 3 above) then
+            e.g. If you want to package bergamot project specific files (downloaded using step 3 above) then
             replace `FILES_TO_PACKAGE` with `../models`
 
         * If you don't want to package any file into wasm binary then execute following commands:
@@ -75,7 +74,7 @@ Bergamot translator provides a unified API for ([Marian NMT](https://marian-nmt.
             emmake make -j
             ```
 
-        The wasm artifacts (.js and .wasm files) will be available in `wasm` folder of build directory ("build-wasm" in this case).
+        The wasm artifacts (.js and .wasm files) will be available in the build directory ("build-wasm" in this case).
 
     3. Enable SIMD Wormhole via Wasm instantiation API in generated artifacts
         ```bash

--- a/wasm/CMakeLists.txt
+++ b/wasm/CMakeLists.txt
@@ -23,6 +23,7 @@ endif()
 set_target_properties(bergamot-translator-worker PROPERTIES
                         SUFFIX ".js"
                         LINK_FLAGS ${LINKER_FLAGS}
-                        )
+                        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+                      )
 
 target_link_libraries(bergamot-translator-worker bergamot-translator)

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -77,8 +77,10 @@ input.delete();
 * Start the test webserver (ensure you have the latest nodejs installed)
     ```bash
     cd test_page
-    bash start_server.sh
+    bash start_server.sh ../../build-wasm
     ```
+
+    Provide the folder containing the wasm artifacts as the first argument of `start_server.sh` script (`../../build-wasm` in this case).
 
 * Open any of the browsers below
     * Firefox Nightly +87: make sure the following prefs are on (about:config)

--- a/wasm/patch-artifacts-enable-wormhole.sh
+++ b/wasm/patch-artifacts-enable-wormhole.sh
@@ -1,7 +1,36 @@
 #!/bin/bash
+usage="Patch wasm artifacts to enable wormhole via APIs that compile and instantiate wasm module.
 
-echo "Patching wasm artifacts to enable wormhole via APIs that compile and instantiate wasm module"
-sed -i.bak 's/WebAssembly.instantiateStreaming[[:space:]]*([[:space:]]*response[[:space:]]*,[[:space:]]*info[[:space:]]*)/WebAssembly.instantiateStreaming(response, info, {simdWormhole:true})/g' wasm/bergamot-translator-worker.js
-sed -i.bak 's/WebAssembly.instantiate[[:space:]]*([[:space:]]*binary[[:space:]]*,[[:space:]]*info[[:space:]]*)/WebAssembly.instantiate(binary, info, {simdWormhole:true})/g' wasm/bergamot-translator-worker.js
-sed -i.bak 's/WebAssembly.Module[[:space:]]*([[:space:]]*bytes[[:space:]]*)/WebAssembly.Module(bytes, {simdWormhole:true})/g' wasm/bergamot-translator-worker.js
+Usage: $(basename "$0") [WASM_ARTIFACTS_FOLDER]
+
+    where:
+    WASM_ARTIFACTS_FOLDER    Folder containing wasm artifacts
+                             (An optional argument, if unspecified the default is: current folder)"
+
+if [ "$#" -gt 1 ]; then
+    echo "Illegal number of parameters passed"
+    echo "$usage"
+    exit
+fi
+
+# Parse wasm artifacts folder if provided via script argument or set it to default
+WASM_ARTIFACTS_FOLDER=$PWD
+if [ "$#" -eq 1 ]; then
+    if [ ! -e "$1" ]; then
+        echo "Error: Folder \""$1"\" doesn't exist"
+        exit
+    fi
+    WASM_ARTIFACTS_FOLDER="$1"
+fi
+
+WASM_ARTIFACTS="$WASM_ARTIFACTS_FOLDER/bergamot-translator-worker.js"
+if [ ! -e "$WASM_ARTIFACTS" ]; then
+    echo "Error: Artifact \"$WASM_ARTIFACTS\" doesn't exist"
+    exit
+fi
+
+echo "Patching \"$WASM_ARTIFACTS\" to enable wormhole via APIs that compile and instantiate wasm module"
+sed -i.bak 's/WebAssembly.instantiateStreaming[[:space:]]*([[:space:]]*response[[:space:]]*,[[:space:]]*info[[:space:]]*)/WebAssembly.instantiateStreaming(response, info, {simdWormhole:true})/g' $WASM_ARTIFACTS
+sed -i.bak 's/WebAssembly.instantiate[[:space:]]*([[:space:]]*binary[[:space:]]*,[[:space:]]*info[[:space:]]*)/WebAssembly.instantiate(binary, info, {simdWormhole:true})/g' $WASM_ARTIFACTS
+sed -i.bak 's/WebAssembly.Module[[:space:]]*([[:space:]]*bytes[[:space:]]*)/WebAssembly.Module(bytes, {simdWormhole:true})/g' $WASM_ARTIFACTS
 echo "Done"

--- a/wasm/test_page/start_server.sh
+++ b/wasm/test_page/start_server.sh
@@ -1,9 +1,30 @@
 #!/bin/bash
-echo "Start: Copying artifacts in local folder------"
-cp ../../build-wasm/wasm/bergamot-translator-worker.data .
-cp ../../build-wasm/wasm/bergamot-translator-worker.js .
-cp ../../build-wasm/wasm/bergamot-translator-worker.wasm .
-cp ../../build-wasm/wasm/bergamot-translator-worker.worker.js .
+
+usage="Copy wasm artifacts from build directory and start httpserver
+
+Usage: $(basename "$0") [WASM_ARTIFACTS_FOLDER]
+
+    where:
+    WASM_ARTIFACTS_FOLDER    Folder containing pre-built wasm artifacts"
+
+if [ "$#" -ne 1 ]; then
+    echo "Illegal number of parameters passed"
+    echo "$usage"
+    exit
+fi
+
+# Check if WASM_ARTIFACTS_FOLDER is valid or not
+if [ ! -e "$1" ]; then
+    echo "Error: Folder \""$1"\" doesn't exist"
+    exit
+fi
+
+WASM_ARTIFACTS="$1/bergamot-translator-worker.*"
+for i in $WASM_ARTIFACTS; do
+    [ -f "$i" ] || breaks
+    cp $i .
+    echo "Copied \"$i\""
+done
 
 npm install
 echo "Start httpserver"


### PR DESCRIPTION
- Build the wasm artifacts in the top level build folder instead of build/wasm folder
- Robust scripts to patch wasm artifacts and starting the http server
    - **There is no change in what they were doing before**
    - Just added an argument to accept the folder where the wasm artifacts reside
- Updated root level README
    - To not package model and lexical files in wasm binary since they are provided at run time
        - It avoids bloating up the wasm binary significantly