### PR TITLE
Extension desired changes

### DIFF
--- a/wasm/CMakeLists.txt
+++ b/wasm/CMakeLists.txt
@@ -23,6 +23,9 @@ endif()
 # Enable worker file system
 set(LINKER_FLAGS "${LINKER_FLAGS} -lworkerfs.js")
 
+# Avoid node.js-code in emscripten glue-code
+set(LINKER_FLAGS "${LINKER_FLAGS} -s ENVIRONMENT=web,worker")
+
 set_target_properties(bergamot-translator-worker PROPERTIES
                         SUFFIX ".js"
                         LINK_FLAGS ${LINKER_FLAGS}

--- a/wasm/CMakeLists.txt
+++ b/wasm/CMakeLists.txt
@@ -20,6 +20,9 @@ if (NOT PACKAGE_DIR STREQUAL "")
   set(LINKER_FLAGS "${LINKER_FLAGS} --preload-file ${REALPATH_PACKAGE_DIR}@/")
 endif()
 
+# Enable worker file system
+set(LINKER_FLAGS "${LINKER_FLAGS} -lworkerfs.js")
+
 set_target_properties(bergamot-translator-worker PROPERTIES
                         SUFFIX ".js"
                         LINK_FLAGS ${LINKER_FLAGS}


### PR DESCRIPTION
This PR includes a couple of changes that makes the glue code compatible with the current bergamot-browser-extension implementation. 

WorkerFS is used to mount remotely downloaded model files (including vocab files) in the emscripten's file system so that no files needs to be bundled in the wasm artifacts. 

Avoiding node.js-code in Emscripten glue-code allows the glue code to be integrated properly in the extension's webpack build configuration.