### PR TITLE
Fix busy loop in windows

### DIFF
--- a/src/translator/pcqueue.h
+++ b/src/translator/pcqueue.h
@@ -114,7 +114,7 @@ class Semaphore {
 
     void wait() {
       while (true) {
-        switch (WaitForSingleObject(sem_, 0L)) {
+        switch (WaitForSingleObject(sem_, INFINITE)) {
           case WAIT_OBJECT_0:
             return;
           case WAIT_ABANDONED:

--- a/src/translator/pcqueue.h
+++ b/src/translator/pcqueue.h
@@ -120,7 +120,6 @@ class Semaphore {
           ABORT("A semaphore can't be abandoned, confused by Windows");
         case WAIT_TIMEOUT:
           ABORT("Timeout on an infinite wait?");
-          continue;
         case WAIT_FAILED:
           ABORT("Waiting on Semaphore failed {}", GetLastError());
       }

--- a/src/translator/pcqueue.h
+++ b/src/translator/pcqueue.h
@@ -113,17 +113,16 @@ class Semaphore {
 
 
     void wait() {
-      while (true) {
-        switch (WaitForSingleObject(sem_, INFINITE)) {
-          case WAIT_OBJECT_0:
-            return;
-          case WAIT_ABANDONED:
-            ABORT("A semaphore can't be abandoned, confused by Windows");
-          case WAIT_TIMEOUT:
-            continue;
-          case WAIT_FAILED:
-            ABORT("Waiting on Semaphore failed {}", GetLastError());
-        }
+      switch (WaitForSingleObject(sem_, INFINITE)) {
+        case WAIT_OBJECT_0:
+          return;
+        case WAIT_ABANDONED:
+          ABORT("A semaphore can't be abandoned, confused by Windows");
+        case WAIT_TIMEOUT:
+          ABORT("Timeout on an infinite wait?");
+          continue;
+        case WAIT_FAILED:
+          ABORT("Waiting on Semaphore failed {}", GetLastError());
       }
     }
 


### PR DESCRIPTION
I had misread the documentation of WaitForSingleObject in https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-waitforsingleobject