### PR TITLE
Remove unused used types TokenRanges, SentenceTokenRanges, UPtr

### DIFF
--- a/src/translator/definitions.h
+++ b/src/translator/definitions.h
@@ -11,16 +11,6 @@ namespace bergamot {
 
 typedef marian::Words Segment;
 typedef std::vector<Segment> Segments;
-typedef std::vector<marian::string_view> TokenRanges;
-typedef std::vector<TokenRanges> SentenceTokenRanges;
-
-/** @brief Creates unique_ptr any type, passes all arguments to any available
- *  * constructor */
-template <class T, typename... Args> UPtr<T> UNew(Args &&... args) {
-  return UPtr<T>(new T(std::forward<Args>(args)...));
-}
-
-template <class T> UPtr<T> UNew(UPtr<T> p) { return UPtr<T>(p); }
 
 /// Shortcut to AlignedVector<char> for byte arrays
 typedef AlignedVector<char> AlignedMemory;


### PR DESCRIPTION
`TokenRanges/SentenceTokenRanges` are all `string_views`/`ByteRange`s, and the ugliness sort-of hidden now by 	`Annotation`.

The UPtr is marian syntax which I don't think this repo will have any use for, use `std::make_unique`, `std::unique_ptr` instead if at all any need be.