### PR TITLE
Enable passing Vocabularies as bytes from JS

### DIFF
--- a/wasm/bindings/TranslationModelBindings.cpp
+++ b/wasm/bindings/TranslationModelBindings.cpp
@@ -24,12 +24,36 @@ EMSCRIPTEN_BINDINGS(aligned_memory) {
     .function("size", &marian::bergamot::AlignedMemory::size)
 	  .function("getByteArrayView", &getByteArrayView)
     ;
+
+    register_vector<marian::bergamot::AlignedMemory*>("AlignedMemoryList");
+}
+
+std::vector<std::shared_ptr<marian::bergamot::AlignedMemory>>
+prepareVocabsSmartMemories(std::vector<marian::bergamot::AlignedMemory*>& vocabsMemories) {
+  auto sourceVocabMemory = std::make_shared<marian::bergamot::AlignedMemory>(std::move(*(vocabsMemories[0])));
+  std::vector<std::shared_ptr<marian::bergamot::AlignedMemory>> vocabsSmartMemories;
+  vocabsSmartMemories.push_back(sourceVocabMemory);
+  // When source and target vocab files are same, only one memory object is passed in vocabsMemories
+  // to avoid double memory allocation for the same file. However, the constructor of the TranslationModel
+  // class still expects 2 entries where each entry has the shared ownership of a single AlignedMemory object.
+  if (vocabsMemories.size() == 2) {
+    auto targetVocabMemory = std::make_shared<marian::bergamot::AlignedMemory>(std::move(*(vocabsMemories[1])));
+    vocabsSmartMemories.push_back(std::move(targetVocabMemory));
+  }
+  else {
+    vocabsSmartMemories.push_back(sourceVocabMemory);
+  }
+  return vocabsSmartMemories;
 }
 
 TranslationModel* TranslationModelFactory(const std::string &config,
                                           marian::bergamot::AlignedMemory* modelMemory,
-                                          marian::bergamot::AlignedMemory* shortlistMemory) {
-  return new TranslationModel(config, std::move(*modelMemory), std::move(*shortlistMemory));
+                                          marian::bergamot::AlignedMemory* shortlistMemory,
+                                          std::vector<marian::bergamot::AlignedMemory*> uniqueVocabsMemories) {
+  return new TranslationModel(config,
+                              std::move(*modelMemory),
+                              std::move(*shortlistMemory),
+                              std::move(prepareVocabsSmartMemories(uniqueVocabsMemories)));
 }
 
 EMSCRIPTEN_BINDINGS(translation_model) {

--- a/wasm/test_page/bergamot.html
+++ b/wasm/test_page/bergamot.html
@@ -113,10 +113,7 @@ shortlist:
 `;
 */
 
-const modelConfigWithoutModelAndShortList = `vocabs:
-  - /${languagePair}/vocab.${vocabLanguagePair}.spm
-  - /${languagePair}/vocab.${vocabLanguagePair}.spm
-beam-size: 1
+const modelConfig = `beam-size: 1
 normalize: 1.0
 word-penalty: 0
 max-length-break: 128
@@ -136,9 +133,15 @@ gemm-precision: int8shift
 // gemm-precision: int8shiftAlphaAll
 
     const modelFile = `models/${languagePair}/model.${languagePair}.intgemm.alphas.bin`;
-    console.debug("modelFile: ", modelFile);
     const shortlistFile = `models/${languagePair}/lex.50.50.${languagePair}.s2t.bin`;
+    const vocabFiles = [`models/${languagePair}/vocab.${vocabLanguagePair}.spm`,
+                        `models/${languagePair}/vocab.${vocabLanguagePair}.spm`];
+
+    const uniqueVocabFiles = new Set(vocabFiles);
+    console.debug("modelFile: ", modelFile);
     console.debug("shortlistFile: ", shortlistFile);
+    console.debug("No. of unique vocabs: ", uniqueVocabFiles.size);
+    uniqueVocabFiles.forEach(item => console.debug("unique vocabFile: ", item));
 
     try {
       // Download the files as buffers from the given urls
@@ -146,16 +149,23 @@ gemm-precision: int8shift
       const downloadedBuffers = await Promise.all([downloadAsArrayBuffer(modelFile), downloadAsArrayBuffer(shortlistFile)]);
       const modelBuffer = downloadedBuffers[0];
       const shortListBuffer = downloadedBuffers[1];
+
+      const downloadedVocabBuffers = [];
+      for (let item of uniqueVocabFiles.values()) {
+        downloadedVocabBuffers.push(await downloadAsArrayBuffer(item));
+      }
       log(`${languagePair} file download took ${(Date.now() - start) / 1000} secs`);
 
       // Construct AlignedMemory objects with downloaded buffers
       var alignedModelMemory = constructAlignedMemoryFromBuffer(modelBuffer, 256);
       var alignedShortlistMemory = constructAlignedMemoryFromBuffer(shortListBuffer, 64);
+      var alignedVocabsMemoryList = new Module.AlignedMemoryList;
+      downloadedVocabBuffers.forEach(item => alignedVocabsMemoryList.push_back(constructAlignedMemoryFromBuffer(item, 64)));
 
       // Instantiate the TranslationModel
       if (translationModel) translationModel.delete();
-      console.debug("Creating TranslationModel with config:", modelConfigWithoutModelAndShortList);
-      translationModel = new Module.TranslationModel(modelConfigWithoutModelAndShortList, alignedModelMemory, alignedShortlistMemory);
+      console.debug("Creating TranslationModel with config:", modelConfig);
+      translationModel = new Module.TranslationModel(modelConfig, alignedModelMemory, alignedShortlistMemory, alignedVocabsMemoryList);
     } catch (error) {
       log(error);
     }


### PR DESCRIPTION
This PR fixes https://github.com/browsermt/bergamot-translator/issues/75

- It enables passing **vocabulary** as bytes from JS environment (completes all tasks mentioned in https://github.com/browsermt/bergamot-translator/issues/75#issuecomment-838534866)
- Super small refactoring in bindings class to make it more readable