### PR TITLE
Remove packaging step from wasm build commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,8 +42,6 @@ option(COMPILE_WASM "Compile for WASM" OFF)
 cmake_dependent_option(USE_WASM_COMPATIBLE_SOURCE "Use wasm compatible sources" OFF "NOT COMPILE_WASM" ON)
 option(COMPILE_TESTS "Compile bergamot-tests" OFF)
 
-SET(PACKAGE_DIR "" CACHE STRING "Directory including all the files to be packaged (pre-loaded) in wasm builds")
-
 # Set 3rd party submodule specific cmake options for this project
 SET(COMPILE_CUDA OFF CACHE BOOL "Compile GPU version")
 SET(USE_SENTENCEPIECE ON CACHE BOOL "Download and compile SentencePiece")

--- a/README.md
+++ b/README.md
@@ -5,85 +5,47 @@ Bergamot translator provides a unified API for ([Marian NMT](https://marian-nmt.
 ## Build Instructions
 
 ### Build Natively
-1. Clone the repository using these instructions:
-    ```bash
-    git clone https://github.com/browsermt/bergamot-translator
-    cd bergamot-translator
-    ```
-2. Compile
+Create a folder where you want to build all the artifacts (`build-native` in this case) and compile
 
-    Create a folder where you want to build all the artifacts (`build-native` in this case) and compile in that folder
-    ```bash
-    mkdir build-native
-    cd build-native
-    cmake ../
-    make -j
-    ```
+```bash
+mkdir build-native
+cd build-native
+cmake ../
+make -j3
+```
 
 ### Build WASM
-#### Compiling for the first time
+#### Prerequisite
 
-1. Download and Install Emscripten using following instructions
-    * Get the latest sdk: `git clone https://github.com/emscripten-core/emsdk.git`
-    * Enter the cloned directory: `cd emsdk`
-    * Install the lastest sdk tools: `./emsdk install latest`
-    * Activate the latest sdk tools: `./emsdk activate latest`
-    * Activate path variables: `source ./emsdk_env.sh`
+Building on wasm requires Emscripten toolchain. It can be downloaded and installed using following instructions:
 
-2. Clone the repository using these instructions:
+* Get the latest sdk: `git clone https://github.com/emscripten-core/emsdk.git`
+* Enter the cloned directory: `cd emsdk`
+* Install the lastest sdk tools: `./emsdk install latest`
+* Activate the latest sdk tools: `./emsdk activate latest`
+* Activate path variables: `source ./emsdk_env.sh`
+
+#### <a name="Compile"></a> Compile
+
+1. Create a folder where you want to build all the artifacts (`build-wasm` in this case) and compile
     ```bash
-    git clone https://github.com/browsermt/bergamot-translator
-    cd bergamot-translator
+    mkdir build-wasm
+    cd build-wasm
+    emcmake cmake -DCOMPILE_WASM=on ../
+    emmake make -j3
     ```
 
-3. Download files (only required if you want to perform inference using build artifacts)
+    The wasm artifacts (.js and .wasm files) will be available in the build directory ("build-wasm" in this case).
 
-    It packages the vocabulary files into wasm binary, which is required only if you want to perform inference.
-    The compilation commands will preload these files in Emscripten’s virtual file system.
-
-    If you want to package bergamot project specific files, please follow these instructions:
+2. Enable SIMD Wormhole via Wasm instantiation API in generated artifacts
     ```bash
-    git clone --depth 1 --branch main --single-branch https://github.com/mozilla-applied-ml/bergamot-models
-    mkdir models
-    cp -rf bergamot-models/prod/* models
-    gunzip models/*/*
-    find models \( -type f -name "model*" -or -type f -name "lex*" \) -delete
+    bash ../wasm/patch-artifacts-enable-wormhole.sh
     ```
-
-4. Compile
-    1. Create a folder where you want to build all the artefacts (`build-wasm` in this case)
-        ```bash
-        mkdir build-wasm
-        cd build-wasm
-        ```
-
-    2. Compile the artefacts
-        * If you want to package files into wasm binary then execute following commands (Replace `FILES_TO_PACKAGE` with the
-        directory containing all the files to be packaged)
-
-            ```bash
-            emcmake cmake -DCOMPILE_WASM=on -DPACKAGE_DIR=FILES_TO_PACKAGE ../
-            emmake make -j
-            ```
-            e.g. If you want to package bergamot project specific files (downloaded using step 3 above) then
-            replace `FILES_TO_PACKAGE` with `../models`
-
-        * If you don't want to package any file into wasm binary then execute following commands:
-            ```bash
-            emcmake cmake -DCOMPILE_WASM=on ../
-            emmake make -j
-            ```
-
-        The wasm artifacts (.js and .wasm files) will be available in the build directory ("build-wasm" in this case).
-
-    3. Enable SIMD Wormhole via Wasm instantiation API in generated artifacts
-        ```bash
-        bash ../wasm/patch-artifacts-enable-wormhole.sh
-        ```
 
 #### Recompiling
-As long as you don't update any submodule, just follow steps in `4.ii` and `4.iii` to recompile.\
-If you update a submodule, execute following command before executing steps in `4.ii` and `4.iii` to recompile.
+As long as you don't update any submodule, just follow [Compile](#Compile) steps.\
+If you update a submodule, execute following command in repository root folder before executing
+[Compile](#Compile) steps.
 ```bash
 git submodule update --init --recursive
 ```

--- a/wasm/CMakeLists.txt
+++ b/wasm/CMakeLists.txt
@@ -14,14 +14,7 @@ target_include_directories(bergamot-translator-worker
 target_compile_definitions(bergamot-translator-worker PRIVATE WASM_BINDINGS)
 target_compile_options(bergamot-translator-worker PRIVATE ${WASM_COMPILE_FLAGS})
 
-set(LINKER_FLAGS "-g2 --bind -s ASSERTIONS=0 -s DISABLE_EXCEPTION_CATCHING=1 -s FORCE_FILESYSTEM=1 -s ALLOW_MEMORY_GROWTH=1 -s NO_DYNAMIC_EXECUTION=1 -s EXPORTED_RUNTIME_METHODS=[addOnPreMain]")
-if (NOT PACKAGE_DIR STREQUAL "")
-  get_filename_component(REALPATH_PACKAGE_DIR ${PACKAGE_DIR} REALPATH BASE_DIR ${CMAKE_BINARY_DIR})
-  set(LINKER_FLAGS "${LINKER_FLAGS} --preload-file ${REALPATH_PACKAGE_DIR}@/")
-endif()
-
-# Enable worker file system
-set(LINKER_FLAGS "${LINKER_FLAGS} -lworkerfs.js")
+set(LINKER_FLAGS "-g2 --bind -s ASSERTIONS=0 -s DISABLE_EXCEPTION_CATCHING=1 -s ALLOW_MEMORY_GROWTH=1 -s NO_DYNAMIC_EXECUTION=1 -s EXPORTED_RUNTIME_METHODS=[addOnPreMain]")
 
 # Avoid node.js-code in emscripten glue-code
 set(LINKER_FLAGS "${LINKER_FLAGS} -s ENVIRONMENT=web,worker")


### PR DESCRIPTION
Model, shortlist and vocabulary files can be passed as bytes. => We can stop packaging these files into wasm during build steps.

This PR:
- Updates READMEs to reflect these changes
- Updates CMakeLists.txt files to remove packaging steps from them
- Updates wasm README to reflect API changes to pass vocab as bytes