### PR TITLE
Fix Unbuntu 16.04 build

### DIFF
--- a/src/translator/definitions.h
+++ b/src/translator/definitions.h
@@ -18,16 +18,16 @@ typedef AlignedVector<char> AlignedMemory;
 /// Memory bundle for all byte-arrays.
 /// Can be a set/subset of model, shortlist, vocabs and ssplitPrefixFile bytes.
 struct MemoryBundle {
-  AlignedMemory model;  ///< Byte-array of model (aligned to 256)
-  AlignedMemory shortlist;  ///< Byte-array of shortlist (aligned to 64)
+  AlignedMemory model{};  ///< Byte-array of model (aligned to 256)
+  AlignedMemory shortlist{};  ///< Byte-array of shortlist (aligned to 64)
 
   /// Vector of vocabulary memories (aligned to 64).
   /// If two vocabularies are the same (based on the filenames), two entries (shared
   /// pointers) will be generated which share the same AlignedMemory object.
-  std::vector<std::shared_ptr<AlignedMemory>> vocabs;
+  std::vector<std::shared_ptr<AlignedMemory>> vocabs{};
 
   /// @todo Not implemented yet
-  AlignedMemory ssplitPrefixFile;
+  AlignedMemory ssplitPrefixFile{};
 };
 
 } // namespace bergamot


### PR DESCRIPTION
This PR addresses https://github.com/browsermt/bergamot-translator/issues/166.
Old version of c++ does not intialise Struct members.
I tested in vahalla, now the build can pass.