### PR TITLE
Adding documentation action

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -2,7 +2,7 @@ name: Documentation
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches: [ $default-branch, ci-sandbox ]
 
 jobs:
   api-documentation:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -16,7 +16,12 @@ jobs:
         with:
           submodules: recursive
 
-      # Be careful if you have a tag named main, bad idea
+      # Runs javascript to extract push events from both tags and branch (only main, due to workflow trigger)
+      # converts refs/<>/<name> -> <name>
+      # eg:
+      #     refs/head/main   -> main
+      #     refs/tags/v0.1.0 -> v0.1.0
+      #
       - name: Extract tag name
         id: tag
         uses: actions/github-script@0.2.0
@@ -28,13 +33,15 @@ jobs:
             [refs, category, ...rest] = args;
             return rest.join("/");
 
-      - name: Deploy-time patch version
-        run: |
-            echo ${{ steps.tag.outputs.result }} > BERGAMOT_VERSION
+      # Patches the BERGAMOT_VERSION file used by sphinx-docs at run time to
+      # obtain names like 'main' or 'ci-sandbox' to not confuse with version
+      # based documentation built separately.
+      - name: Deploy-time patch version 
+        run: | 
+            echo ${{steps.tag.outputs.result }} > BERGAMOT_VERSION
 
       - name: Set up Doxygen
         run: sudo apt-get install -y doxygen
-
 
       - name: Set up Python
         uses: actions/setup-python@v2
@@ -70,6 +77,8 @@ jobs:
 
       # This artifact contains the HTML output of Sphinx only.
       # With index.html at the root of the produced zip file.
+      # For use for maintainers to download the zip and check render of
+      # documentation while generated at pull-request. 
       - name: Upload documentation
         uses: actions/upload-artifact@v2
         if: ${{ github.event_name == 'pull_request'}}

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -2,7 +2,7 @@ name: Documentation
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   api-documentation:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -42,3 +42,13 @@ jobs:
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: ./doc/build/ # The folder the action should deploy.
+
+      # This artifact contains the HTML output of Sphinx only.
+      # With index.html at the root of the produced zip file.
+      - name: Upload documentation
+        uses: actions/upload-artifact@v2
+        with:
+          name: api-docs
+          path: ./doc/build/
+          if-no-files-found: error
+

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -57,9 +57,11 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@4.1.3
         if: ${{ github.event_name == 'push' }}
         with:
+          repository-name: 'browsermt/docs' 
           branch: gh-pages # The branch the action should deploy to.
           folder: './doc/build/' # The folder the action should deploy.
           target-folder: '${{ steps.tag.outputs.result }}' 
+          ssh-key: ${{ secrets.BERGAMOT_SSH_PRIVATE_KEY }}
 
       # This artifact contains the HTML output of Sphinx only.
       # With index.html at the root of the produced zip file.

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -2,9 +2,7 @@ name: Documentation
 
 on:
   push:
-    branches: [ master, ci-sandbox ]
-  pull_request:
-    branches: [ master, ci-sandbox ]
+    branches: [ master ]
 
 jobs:
   api-documentation:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const args = s.split("/");
+            const args = context.payload.ref.split("/");
             [refs, category, ...rest] = args;
             return rest.join("/");
 

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [ $default-branch, ci-sandbox ]
     tags: ['v[0-9]+.[0-9]+.[0-9]+']
+  pull_request: 
+    branches: [ $default-branch ]
 
 jobs:
   api-documentation:
@@ -51,6 +53,7 @@ jobs:
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@4.1.3
+        if: ${{ github.event_name == 'push' }}
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: './doc/build/' # The folder the action should deploy.
@@ -60,6 +63,7 @@ jobs:
       # With index.html at the root of the produced zip file.
       - name: Upload documentation
         uses: actions/upload-artifact@v2
+        if: ${{ github.event_name == 'pull_request'}}
         with:
           name: api-docs
           path: ./doc/build/

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -46,7 +46,8 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@4.1.3
         with:
           branch: gh-pages # The branch the action should deploy to.
-          folder: './doc/build/${{ steps.get_version.outputs.VERSION }}' # The folder the action should deploy.
+          folder: './doc/build/' # The folder the action should deploy.
+          target-folder: '${{ steps.get_version.outputs.VERSION }}' 
 
       # This artifact contains the HTML output of Sphinx only.
       # With index.html at the root of the produced zip file.

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -52,4 +52,4 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@4.1.3
         with:
           branch: gh-pages # The branch the action should deploy to.
-          folder: ./doc/build/html # The folder the action should deploy.
+          folder: ./doc/build/ # The folder the action should deploy.

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Build documentation
         working-directory: ./doc
-        run: make html
+        run: sphinx-quickstart && make html
 
       # This artifact contains the HTML output of Sphinx only.
       # With index.html at the root of the produced zip file.

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -17,9 +17,13 @@ jobs:
       - name: Set up Doxygen
         run: sudo apt-get install -y doxygen
 
-      - name: Get the version
-        id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      - name: Extract tag name
+        id: tag
+        uses: actions/github-script@0.2.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            return context.payload.ref.replace(/\/refs\/tags\//, '');
 
       - name: Set up Python
         uses: actions/setup-python@v2
@@ -47,7 +51,7 @@ jobs:
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: './doc/build/' # The folder the action should deploy.
-          target-folder: '${{ steps.get_version.outputs.VERSION }}' 
+          target-folder: '${{ steps.tag.outputs.result }}' 
 
       # This artifact contains the HTML output of Sphinx only.
       # With index.html at the root of the produced zip file.

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -19,16 +19,6 @@ jobs:
       - name: Set up Doxygen
         run: sudo apt-get install -y doxygen
 
-      # Be careful if you have a tag named main, bad idea
-      - name: Extract tag name
-        id: tag
-        uses: actions/github-script@0.2.0
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const args = context.payload.ref.split("/");
-            [refs, category, ...rest] = args;
-            return rest.join("/");
 
       - name: Set up Python
         uses: actions/setup-python@v2
@@ -50,6 +40,18 @@ jobs:
       - name: Build documentation
         working-directory: ./doc
         run: sphinx-build -b html ./ build/
+
+      # Be careful if you have a tag named main, bad idea
+      - name: Extract tag name
+        id: tag
+        uses: actions/github-script@0.2.0
+        if: ${{ github.event_name == 'push' }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const args = context.payload.ref.split("/");
+            [refs, category, ...rest] = args;
+            return rest.join("/");
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@4.1.3

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Build documentation
         working-directory: ./doc
-        run: sphinx-quickstart && make html
+        run: sphinx-build -b html ./ build/
 
       # This artifact contains the HTML output of Sphinx only.
       # With index.html at the root of the produced zip file.

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -17,13 +17,16 @@ jobs:
       - name: Set up Doxygen
         run: sudo apt-get install -y doxygen
 
+      # Be careful if you have a tag named main, bad idea
       - name: Extract tag name
         id: tag
         uses: actions/github-script@0.2.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            return context.payload.ref.replace(/\/refs\/tags\//, '');
+            const args = s.split("/");
+            [refs, category, ...rest] = args;
+            return rest.join("/");
 
       - name: Set up Python
         uses: actions/setup-python@v2

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Deploy-time patch version
         run: |
-            echo '${{ steps.tag.outputs.result }}' > BERGAMOT_VERSION
+            echo ${{ steps.tag.outputs.result }} > BERGAMOT_VERSION
 
       - name: Set up Doxygen
         run: sudo apt-get install -y doxygen

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -16,6 +16,22 @@ jobs:
         with:
           submodules: recursive
 
+      # Be careful if you have a tag named main, bad idea
+      - name: Extract tag name
+        id: tag
+        uses: actions/github-script@0.2.0
+        if: ${{ github.event_name == 'push' }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const args = context.payload.ref.split("/");
+            [refs, category, ...rest] = args;
+            return rest.join("/");
+
+      - name: Deploy-time patch version
+        run: |
+            echo '${{ steps.tag.outputs.result }}' > BERGAMOT_VERSION
+
       - name: Set up Doxygen
         run: sudo apt-get install -y doxygen
 
@@ -41,17 +57,6 @@ jobs:
         working-directory: ./doc
         run: sphinx-build -b html ./ build/
 
-      # Be careful if you have a tag named main, bad idea
-      - name: Extract tag name
-        id: tag
-        uses: actions/github-script@0.2.0
-        if: ${{ github.event_name == 'push' }}
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const args = context.payload.ref.split("/");
-            [refs, category, ...rest] = args;
-            return rest.join("/");
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@4.1.3

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,55 @@
+name: Documentation
+
+on:
+  push:
+    branches: [ master, ci-sandbox ]
+  pull_request:
+    branches: [ master, ci-sandbox ]
+
+jobs:
+  api-documentation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Set up Doxygen
+        run: sudo apt-get install -y doxygen
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Set up dependency cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('doc/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        working-directory: ./doc
+        run: python3 -m pip install -r requirements.txt
+
+      - name: Build documentation
+        working-directory: ./doc
+        run: make html
+
+      # This artifact contains the HTML output of Sphinx only.
+      # With index.html at the root of the produced zip file.
+      - name: Upload documentation
+        uses: actions/upload-artifact@v2
+        with:
+          name: api-docs
+          path: ./doc/build/html
+          if-no-files-found: error
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@4.1.3
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: ./doc/build/html # The folder the action should deploy.

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -3,6 +3,7 @@ name: Documentation
 on:
   push:
     branches: [ $default-branch, ci-sandbox ]
+    tags: ['v[0-9]+.[0-9]+.[0-9]+']
 
 jobs:
   api-documentation:
@@ -15,6 +16,10 @@ jobs:
 
       - name: Set up Doxygen
         run: sudo apt-get install -y doxygen
+
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
 
       - name: Set up Python
         uses: actions/setup-python@v2
@@ -41,7 +46,7 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@4.1.3
         with:
           branch: gh-pages # The branch the action should deploy to.
-          folder: ./doc/build/ # The folder the action should deploy.
+          folder: './doc/build/${{ steps.get_version.outputs.VERSION }}' # The folder the action should deploy.
 
       # This artifact contains the HTML output of Sphinx only.
       # With index.html at the root of the produced zip file.

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -39,15 +39,6 @@ jobs:
         working-directory: ./doc
         run: sphinx-build -b html ./ build/
 
-      # This artifact contains the HTML output of Sphinx only.
-      # With index.html at the root of the produced zip file.
-      - name: Upload documentation
-        uses: actions/upload-artifact@v2
-        with:
-          name: api-docs
-          path: ./doc/build/html
-          if-no-files-found: error
-
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@4.1.3
         with:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -2,7 +2,7 @@ name: Documentation
 
 on:
   push:
-    branches: [ main ]
+    branches: [ $default-branch ]
 
 jobs:
   api-documentation:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -2,10 +2,10 @@ name: Documentation
 
 on:
   push:
-    branches: [ $default-branch, ci-sandbox ]
+    branches: [ main, ci-sandbox ]
     tags: ['v[0-9]+.[0-9]+.[0-9]+']
   pull_request: 
-    branches: [ $default-branch ]
+    branches: [ main ]
 
 jobs:
   api-documentation:


### PR DESCRIPTION
Uploads latest documentation to repository's gh-pages branch.

There ~~can be~~ is some trickery to do this per version and also latest, like how docs are normally structured. Have latest `v<major>.<minor>.<suffix>` corresponding to releases as well.

Here's demonstration of a successful run on my fork:

* https://github.com/jerinphilip/bergamot-translator/runs/2625000572?check_suite_focus=true
* https://jerinphilip.github.io/bergamot-translator/ (sample-render)

Also could have doxygen warn about undocumented members, but maybe in a later PR.

The yaml is borrowed from @graemenail, upload-artifact ~~cut~~ only on pull request, gh-pages publish moved in. 