### PR TITLE
Pin emsdk version to the same one used in Circle CI (#165)

### DIFF
--- a/build-wasm.sh
+++ b/build-wasm.sh
@@ -30,8 +30,8 @@ if [ "$EMSDK" == "" ]; then
   fi
   if [ "$EMSDK_UPDATE_REQUIRED" == "1" ]; then
     cd emsdk
-    ./emsdk install latest
-    ./emsdk activate latest
+    ./emsdk install 2.0.9
+    ./emsdk activate 2.0.9
     cd -
   fi
   source ./emsdk/emsdk_env.sh


### PR DESCRIPTION
Not meant to be merged, only to clarify the differences of this branch and the v0.3.1 tag. This change was necessary to build the wasm artifacts from a fresh clone. Artifacts built with the most recent emsdk are not compatible with the extension currently. 