### PR TITLE
Remove O(N^2) reallocation

### DIFF
--- a/src/translator/annotation.cpp
+++ b/src/translator/annotation.cpp
@@ -13,8 +13,6 @@ AnnotatedText::AnnotatedText(std::string &&t) : text(std::move(t)) {
 void AnnotatedText::appendSentence(string_view prefix, std::vector<string_view>::iterator begin,
                                    std::vector<string_view>::iterator end) {
   assert(annotation.token_begin_.back() == text.size());
-  // We'll be adding tokens from the sentence and another gap.
-  annotation.token_begin_.reserve(annotation.token_begin_.size() + (end - begin) + 1);
 
   // prefix is just end of the previous one.
   appendEndingWhitespace(prefix);


### PR DESCRIPTION
Remove O(N^2) reallocation. Fixes https://github.com/browsermt/bergamot-translator-tests/issues/30. 

<details>
<summary>speed regression-tests pass now</summary>

```
jphilip@var:~/code/bergamot-translator-test-scripts$ MARIAN=/mnt/Storage/jphilip/bergamot-build TIMEOUT=30m BRT_THREADS=40 BRT_EXPECTED_MAXTIME=500 ./run_brt.sh speed-tests/test_wngt20_perf.sh
[05/21/2021 17:02:20] Running on var as process 50502
[05/21/2021 17:02:20] Version: v1.9.56 80e47424 2021-05-18 10:55:11 +0100
[05/21/2021 17:02:20] Build type: Release
[05/21/2021 17:02:20] Using compiler: /usr/bin/c++
[05/21/2021 17:02:20] Using MKL: USE_MKL=ON
[05/21/2021 17:02:20] Using CUDNN:
[05/21/2021 17:02:20] Using SentencePiece: USE_SENTENCEPIECE=ON
[05/21/2021 17:02:20] Using FBGEMM:
[05/21/2021 17:02:20] Unit tests: COMPILE_TESTS=on
[05/21/2021 17:02:20] Using time out: 30m
[05/21/2021 17:02:20] Checking directory: speed-tests
[05/21/2021 17:02:20] Running speed-tests/test_wngt20_perf.sh ... OK
[05/21/2021 17:11:00] Test took 00:08:40.271s
---------------------
Ran 1 tests in 00:08:40.323s, 1 passed, 0 skipped, 0 failed
```

</details>