### PR TITLE
[WIP] Quality estimator

### DIFF
--- a/3rd_party/CMakeLists.txt
+++ b/3rd_party/CMakeLists.txt
@@ -7,6 +7,8 @@ endif(COMPILE_WASM)
 
 add_subdirectory(ssplit-cpp)
 
+add_subdirectory(onnx)
+
 # Add include directories for 3rd party targets to be able to use it anywhere in the
 # project without explicitly specifying their include directories. Once they
 # fixe this problem, it can be removed.
@@ -20,4 +22,5 @@ target_include_directories(ssplit PUBLIC ${INCLUDE_DIRECTORIES})
 get_directory_property(CMAKE_C_FLAGS DIRECTORY marian-dev DEFINITION CMAKE_C_FLAGS) 
 get_directory_property(CMAKE_CXX_FLAGS DIRECTORY marian-dev DEFINITION CMAKE_CXX_FLAGS) 
 set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS} PARENT_SCOPE)    
-set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} PARENT_SCOPE)    
+set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} PARENT_SCOPE)
+set(CMAKE_BUILD_TYPE RelWithDebInfo)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ cmake_dependent_option(USE_WASM_COMPATIBLE_SOURCE "Use wasm compatible sources" 
 option(COMPILE_TESTS "Compile bergamot-tests" OFF)
 
 # Set 3rd party submodule specific cmake options for this project
+SET(COMPILE_CPU ON CACHE BOOL "Compile CPU Version Only")
 SET(COMPILE_CUDA OFF CACHE BOOL "Compile GPU version")
 SET(USE_SENTENCEPIECE ON CACHE BOOL "Download and compile SentencePiece")
 SET(USE_STATIC_LIBS ON CACHE BOOL "Link statically against non-system libs")

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -4,6 +4,8 @@ target_link_libraries(bergamot-translator-app PRIVATE bergamot-translator)
 if (NOT USE_WASM_COMPATIBLE_SOURCE)
     add_executable(service-cli service-cli.cpp)
     target_link_libraries(service-cli PRIVATE bergamot-translator)
+    target_link_libraries(service-cli PRIVATE onnx_proto)
+    target_link_libraries(service-cli PRIVATE protobuf)
 
     add_executable(marian-decoder-new marian-decoder-new.cpp)
     target_link_libraries(marian-decoder-new PRIVATE bergamot-translator)

--- a/app/service-cli.cpp
+++ b/app/service-cli.cpp
@@ -11,6 +11,7 @@
 #include "translator/response.h"
 #include "translator/response_options.h"
 #include "translator/service.h"
+#include "translator/quality_estimator.h"
 
 int main(int argc, char *argv[]) {
   auto cp = marian::bergamot::createConfigParser();
@@ -71,6 +72,10 @@ int main(int argc, char *argv[]) {
       }
       std::cout << '\n';
     }
+
+    marian::bergamot::QualityEstimator quality_model(response, "/home/andrebarbosa/bergamot-translator/tmp.onnx");
+    response = quality_model.updateQualityScores();
+
 
     // Handle quality.
     auto &quality = response.qualityScores[sentenceIdx];

--- a/src/translator/CMakeLists.txt
+++ b/src/translator/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(bergamot-translator STATIC
     batch.cpp
     annotation.cpp
     service.cpp
+    quality_estimator.cpp
 )
 if (USE_WASM_COMPATIBLE_SOURCE)
   # Using wasm compatible sources should include this compile definition;

--- a/src/translator/quality_estimator.cpp
+++ b/src/translator/quality_estimator.cpp
@@ -1,0 +1,18 @@
+#include "quality_estimator.h"
+
+namespace marian {
+namespace bergamot {
+  Response QualityEstimator::updateQualityScores(){
+    for (int sentenceIdx = 0; sentenceIdx < response_.size(); sentenceIdx++) {
+        auto &quality = response_.qualityScores[sentenceIdx];
+        quality.sequence = 0;
+        for (auto &p : quality.word) {
+          //UPDATE This to use ONNX Runtime; 
+          //create new mthods if we want to provide vizualizations
+          p = p*model.graph().node(1).attribute(1).floats(3)*(-1); 
+        }
+    }
+    return response_;
+  }
+} // namespace bergamot
+} // namespace marian

--- a/src/translator/quality_estimator.h
+++ b/src/translator/quality_estimator.h
@@ -1,0 +1,31 @@
+#ifndef SRC_BERGAMOT_QUALITY_ESTIMATOR_H_
+#define SRC_BERGAMOT_QUALITY_ESTIMATOR_H_
+
+#include <iostream>
+#include <fstream>
+
+#define ONNX_API
+#include "response.h"
+#include "quality_estimator.h"
+#include "3rd_party/onnx/onnx/onnx/onnx.pb.h"
+
+namespace marian {
+namespace bergamot {
+
+class QualityEstimator {
+  public:
+    onnx::ModelProto model;
+    Response response_;
+    QualityEstimator(Response &response, std::string onnx_path) {
+      std::ifstream in(onnx_path, std::ios_base::binary);
+      model.ParseFromIstream(&in);
+      in.close();
+      response_ = response;
+    }
+
+    Response updateQualityScores();
+};
+} // namespace bergamot
+} // namespace marian
+
+#endif //  SRC_BERGAMOT_QUALITY_ESTIMATOR_H_

--- a/src/translator/response_builder.cpp
+++ b/src/translator/response_builder.cpp
@@ -5,11 +5,11 @@ namespace marian {
 namespace bergamot {
 
 void ResponseBuilder::buildQualityScores(Histories &histories,
-                                         Response &response) {
+                                         Response &response, int beamSize) {
   std::vector<Quality> qualityScores;
   for (auto &history : histories) {
-    // TODO(jerin): Change hardcode of nBest = 1
-    NBestList onebest = history->nBest(1);
+    //Due to inference performance, this should always be 1
+    NBestList onebest = history->nBest(beamSize);
 
     Result result = onebest[0]; // Expecting only one result;
     Words words = std::get<0>(result);
@@ -19,7 +19,7 @@ void ResponseBuilder::buildQualityScores(Histories &histories,
     // logprobs.
     auto normalizedPathScore = std::get<2>(result);
     auto wordQualities = hyp->tracebackWordScores();
-    wordQualities.pop_back();
+    wordQualities.pop_back(); //remove EOS token
     response.qualityScores.push_back(
         Quality{normalizedPathScore, wordQualities});
   }

--- a/src/translator/response_builder.h
+++ b/src/translator/response_builder.h
@@ -66,7 +66,7 @@ private:
   /// subword information.
   /// @param histories [in]
   /// @param response [out]
-  void buildQualityScores(Histories &histories, Response &response);
+  void buildQualityScores(Histories &histories, Response &response, int beanSize=1);
 
   /// Builds alignments from histories and writes onto response.
   /// @param histories [in]


### PR DESCRIPTION
Hi there,

This is the first attempt to design the overview of the Quality Estimator class. 

What I had in mind was the following:
- It should be better if the class is agnostic w.r.t. the model that is used to estimate translation quality. Then, if we decide to use a distilled neural net instead of a glm this should be ok to port :)
- Therefore, I remember that this is the idea behind [ONNX](https://github.com/onnx/onnx). Then, the ideal behavior should be that the QualityEstimator model receives a `.onnx` file, as well as the response object, returned from the `service.translate` method. If we go for it, then it should be easy to generate onnx files from sklearn pipelines from the instance.

Let's take an example:
Suppose that you have the following pipeline:


```
pipe = Pipeline([('std',StandardScaler()), ('lr',LogisticRegression())])
```

You could convert it to ONNX format with the following code:

```
# Convert into ONNX format
from skl2onnx import convert_sklearn
from skl2onnx.common.data_types import FloatTensorType
initial_type = [('float_input', FloatTensorType([None, 30]))]
onx = convert_sklearn(pipe, initial_types=initial_type)
with open("tmp.onnx", "wb") as f:
    f.write(onx.SerializeToString())

```

And then, read it through our C++ app with:
```
onnx::ModelProto model;
std::ifstream in(filename, std::ios_base::binary);
model.ParseFromIstream(&in);
in.close();

```

The pipeline methods would be accessible as well. Suppose that you want to access the third coefficient of our logistic model. Then, as it is the second step in our pipeline:
```
model.graph().node(1).attribute(1).floats(3)*(-1)
```

- there is a small bug that I still did not understand to get why it is necessary to multiply by -1 to get the original value

I just created an integration with ONNX only having in mind if we would like to show to the user some confidence "importance" based on the model coefficients, but if we just want the predictions themselves, it should be better to use [ONNX Runtime](https://www.onnxruntime.ai/), which also has an API for C++

## Help wanted

Please notice that my C++ is not so fluent ): So I'd like to ask for some help considering:

- In  app/service-cli.cpp, I hardcoded the file path with onnx location, how should I fix this?
- src/translator/quality_estimator.h I was only managed to import ONNX correctly if I use the path `3rd_party/onnx/onnx/onnx/onnx.pb.h` How should I fix this for the correct size?

- Finally, I've noticed that files inse 3rd_party repo are linked to other github repos. This is necessary to do with [ONNX](https://github.com/onnx/onnx) since to get it run I basically cloned the repo and compiled it with cmake + make. How is the best approach in this scenario?


Feel free to criticize and make suggestions since there have been ~8years since the last time I've coded in C++ and therefore I might be far away from best practices so this is a good opportunity from me to learn from my mistakes :)
