### PR TITLE
Remove addSentenceWithPriority

### DIFF
--- a/src/translator/batcher.cpp
+++ b/src/translator/batcher.cpp
@@ -16,12 +16,6 @@ Batcher::Batcher(Ptr<Options> options) {
            "longer than what can fit in a batch.");
 }
 
-void Batcher::addSentenceWithPriority(RequestSentence &sentence) {
-  size_t bucket_id = sentence.numTokens();
-  assert(bucket_id < bucket_.size());
-  bucket_[bucket_id].insert(sentence);
-}
-
 bool Batcher::cleaveBatch(Batch &batch) {
   // For now simply iterates on buckets and converts batches greedily.  This
   // has to be enhanced with optimizing over priority. The baseline
@@ -52,8 +46,10 @@ bool Batcher::cleaveBatch(Batch &batch) {
 
 void Batcher::addWholeRequest(Ptr<Request> request) {
   for (size_t i = 0; i < request->numSegments(); i++) {
-    RequestSentence requestSentence(i, request);
-    addSentenceWithPriority(requestSentence);
+    RequestSentence sentence(i, request);
+    size_t bucket_id = sentence.numTokens();
+    assert(bucket_id < bucket_.size());
+    bucket_[bucket_id].insert(sentence);
   }
 }
 

--- a/src/translator/batcher.h
+++ b/src/translator/batcher.h
@@ -19,7 +19,6 @@ class Batcher {
   // RequestSentence incorporates (tentative) notions of priority with each
   // sentence. This method inserts the sentence into the internal data-structure
   // which maintains priority among sentences from multiple concurrent requests.
-  void addSentenceWithPriority(RequestSentence &sentence);
   void addWholeRequest(Ptr<Request> request);
 
   // indicate no more sentences will be added.  Does nothing here, for parity to threadsafe version.

--- a/src/translator/threadsafe_batcher.cpp
+++ b/src/translator/threadsafe_batcher.cpp
@@ -10,14 +10,6 @@ ThreadsafeBatcher::ThreadsafeBatcher(Ptr<Options> options) : backend_(options), 
 
 ThreadsafeBatcher::~ThreadsafeBatcher() { shutdown(); }
 
-void ThreadsafeBatcher::addSentenceWithPriority(RequestSentence &sentence) {
-  std::unique_lock<std::mutex> lock(mutex_);
-  assert(!shutdown_);
-  backend_.addSentenceWithPriority(sentence);
-  ++enqueued_;
-  work_.notify_one();
-}
-
 void ThreadsafeBatcher::addWholeRequest(Ptr<Request> request) {
   std::unique_lock<std::mutex> lock(mutex_);
   assert(!shutdown_);

--- a/src/translator/threadsafe_batcher.h
+++ b/src/translator/threadsafe_batcher.h
@@ -27,7 +27,6 @@ class ThreadsafeBatcher {
 
   // Add sentences to be translated by calling these (see Batcher).  When
   // done, call shutdown.
-  void addSentenceWithPriority(RequestSentence &sentence);
   void addWholeRequest(Ptr<Request> request);
   void shutdown();
 


### PR DESCRIPTION
This removes the unused `addSentenceWithPriority` function and inlines the one caller it had.  