### PR TITLE
Fixing if syntax in periodic push workflow

### DIFF
--- a/.github/workflows/push-browsermt-main-to-mozilla-main.yml
+++ b/.github/workflows/push-browsermt-main-to-mozilla-main.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Mirror a branch from a remote repo into this one
-        if: github.repository == '${{ env.this_repository }}'
+        if: ${{ github.repository == env.this_repository }}
         run: |
           git clone -b ${{ env.branch }} https://github.com/${{ env.source_repository }}.git source
           cd source


### PR DESCRIPTION
> When you use expressions in an if conditional, you may omit the expression syntax (${{ }}) because GitHub automatically evaluates the if conditional as an expression, unless the expression contains any operators. If the expression contains any operators, the expression must be contained within ${{ }} to explicitly mark it for evaluation. For more information about if conditionals, see "Workflow syntax for GitHub Actions."

https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#about-contexts-and-expressions

Copying over from https://github.com/jerinphilip/gh-workflow-multi-repo-sync-mirror/blob/3ccc0f66ba97e9a3662ade8f9a5e1c421529df0a/.github/workflows/mirror.yml#L23, should work hopefully.