### PR TITLE
Consistent EMSDK version and parallel make jobs

### DIFF
--- a/.github/workflows/wasm-custom_marian-mac.yml
+++ b/.github/workflows/wasm-custom_marian-mac.yml
@@ -13,7 +13,9 @@ jobs:
 
     steps:
       - name: Setup Emscripten toolchain
-        uses: mymindstorm/setup-emsdk@v8
+        uses: mymindstorm/setup-emsdk@v9
+        with:
+          version: 2.0.9
 
       - name: Verify Emscripten setup
         run: emcc -v

--- a/.github/workflows/wasm-custom_marian-ubuntu.yml
+++ b/.github/workflows/wasm-custom_marian-ubuntu.yml
@@ -13,7 +13,9 @@ jobs:
 
     steps:
       - name: Setup Emscripten toolchain
-        uses: mymindstorm/setup-emsdk@v8
+        uses: mymindstorm/setup-emsdk@v9
+        with:
+          version: 2.0.9
 
       - name: Verify Emscripten setup
         run: emcc -v

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Create a folder where you want to build all the artifacts (`build-native` in thi
 mkdir build-native
 cd build-native
 cmake ../
-make -j3
+make -j2
 ```
 
 ### Build WASM
@@ -23,8 +23,8 @@ Building on wasm requires Emscripten toolchain. It can be downloaded and install
 
 * Get the latest sdk: `git clone https://github.com/emscripten-core/emsdk.git`
 * Enter the cloned directory: `cd emsdk`
-* Install the lastest sdk tools: `./emsdk install latest`
-* Activate the latest sdk tools: `./emsdk activate latest`
+* Install the lastest sdk tools: `./emsdk install 2.0.9`
+* Activate the latest sdk tools: `./emsdk activate 2.0.9`
 * Activate path variables: `source ./emsdk_env.sh`
 
 #### <a name="Compile"></a> Compile
@@ -34,7 +34,7 @@ Building on wasm requires Emscripten toolchain. It can be downloaded and install
     mkdir build-wasm
     cd build-wasm
     emcmake cmake -DCOMPILE_WASM=on ../
-    emmake make -j3
+    emmake make -j2
     ```
 
     The wasm artifacts (.js and .wasm files) will be available in the build directory ("build-wasm" in this case).

--- a/build-wasm.sh
+++ b/build-wasm.sh
@@ -9,10 +9,8 @@ set -x
 cd "$(dirname $0)"
 
 # This file replicates the instructions found in ./README.md under "Build WASM"
-# with slight adjustments to be able to run the build script multiple times without having to clone all dependencies
-# as per "As long as you don't update any submodule, just follow steps in `4.ii` to recompile."
 
-# 1. Download and Install Emscripten using following instructions (unless the EMSDK env var is already set)
+# Prerequisite: Download and Install Emscripten using following instructions (unless the EMSDK env var is already set)
 if [ "$EMSDK" == "" ]; then
   EMSDK_UPDATE_REQUIRED=0
   if [ ! -d "emsdk" ]; then
@@ -37,18 +35,16 @@ if [ "$EMSDK" == "" ]; then
   source ./emsdk/emsdk_env.sh
 fi
 
-# 4. Compile
-#     1. Create a folder where you want to build all the artifacts (`build-wasm` in this case)
+# Compile
+#    1. Create a folder where you want to build all the artifacts (`build-wasm` in this case) and compile
 if [ ! -d "build-wasm" ]; then
   mkdir build-wasm
 fi
 cd build-wasm
-
-#     2. Compile the artifacts
 emcmake cmake -DCOMPILE_WASM=on ../
-emmake make -j3
+emmake make -j2
 
-#     3. Enable SIMD Wormhole via Wasm instantiation API in generated artifacts
+#     2. Enable SIMD Wormhole via Wasm instantiation API in generated artifacts
 bash ../wasm/patch-artifacts-enable-wormhole.sh
 
 # The artifacts (.js and .wasm files) will be available in the build directory ("build-wasm" in this case).


### PR DESCRIPTION
- Set EMSDK version to 2.0.9 to make it consistent
   everywhere in repo
- Set parallel make jobs to 2

It resolves the issue because of which PR https://github.com/browsermt/bergamot-translator/pull/165 was created.