### PR TITLE
Ability to extract individual sentences in JS

### DIFF
--- a/src/translator/annotation.h
+++ b/src/translator/annotation.h
@@ -6,17 +6,10 @@
 #include <vector>
 
 #include "data/types.h"
+#include "definitions.h"
 
 namespace marian {
 namespace bergamot {
-
-/// ByteRange stores indices for half-interval [begin, end) in a string. Can be
-/// used to represent a sentence, word.
-struct ByteRange {
-  size_t begin;
-  size_t end;
-  const size_t size() const { return end - begin; }
-};
 
 /// Annotation expresses sentence and token boundary information as ranges of
 /// bytes in a string, but does not itself own the string.

--- a/src/translator/definitions.h
+++ b/src/translator/definitions.h
@@ -31,6 +31,14 @@ struct MemoryBundle {
   AlignedMemory ssplitPrefixFile{};
 };
 
+/// ByteRange stores indices for half-interval [begin, end) in a string. Can be
+/// used to represent a sentence, word.
+struct ByteRange {
+  size_t begin;
+  size_t end;
+  const size_t size() const { return end - begin; }
+};
+
 }  // namespace bergamot
 }  // namespace marian
 

--- a/src/translator/response.h
+++ b/src/translator/response.h
@@ -65,6 +65,16 @@ struct Response {
   /// to (sub-)words accessible through Annotation.
   std::vector<Alignment> alignments;
 
+  /// Returns the source sentence (in terms of byte range) corresponding to sentenceIdx.
+  ///
+  /// @param [in] sentenceIdx: The index representing the sentence where 0 <= sentenceIdx < Response::size()
+  ByteRange getSourceSentenceAsByteRange(size_t sentenceIdx) const { return source.sentenceAsByteRange(sentenceIdx); }
+
+  /// Returns the translated sentence (in terms of byte range) corresponding to sentenceIdx.
+  ///
+  /// @param [in] sentenceIdx: The index representing the sentence where 0 <= sentenceIdx < Response::size()
+  ByteRange getTargetSentenceAsByteRange(size_t sentenceIdx) const { return target.sentenceAsByteRange(sentenceIdx); }
+
   const std::string &getOriginalText() const { return source.text; }
 
   const std::string &getTranslatedText() const { return target.text; }

--- a/wasm/bindings/response_bindings.cpp
+++ b/wasm/bindings/response_bindings.cpp
@@ -14,11 +14,20 @@ typedef marian::bergamot::Response Response;
 using namespace emscripten;
 
 // Binding code
+EMSCRIPTEN_BINDINGS(byte_range) {
+  value_object<marian::bergamot::ByteRange>("ByteRange")
+      .field("begin", &marian::bergamot::ByteRange::begin)
+      .field("end", &marian::bergamot::ByteRange::end);
+}
+
 EMSCRIPTEN_BINDINGS(response) {
   class_<Response>("Response")
       .constructor<>()
+      .function("size", &Response::size)
       .function("getOriginalText", &Response::getOriginalText)
-      .function("getTranslatedText", &Response::getTranslatedText);
+      .function("getTranslatedText", &Response::getTranslatedText)
+      .function("getSourceSentence", &Response::getSourceSentenceAsByteRange)
+      .function("getTranslatedSentence", &Response::getTargetSentenceAsByteRange);
 
   register_vector<Response>("VectorResponse");
 }

--- a/wasm/test_page/bergamot.html
+++ b/wasm/test_page/bergamot.html
@@ -81,6 +81,8 @@ En consecuencia, durante el año 2011 se introdujeron 180 proyectos de ley que r
   }
 
   var translationService, responseOptions, input = undefined;
+  const encoder = new TextEncoder(); // string to utf-8 converter
+  const decoder = new TextDecoder(); // utf-8 to string converter
   const constructTranslationService = async (from, to) => {
 
     const languagePair = `${from}${to}`;
@@ -188,16 +190,54 @@ gemm-precision: int8shift
     // Access input (just for debugging)
     console.log('Input size=', input.size());
 
-    // Translate the input; the result is a vector<Response>
+    // Translate the input, which is a vector<String>; the result is a vector<Response>
     let result = translationService.translate(input, responseOptions);
+
     const translatedParagraphs = [];
+    const translatedSentencesOfParagraphs = [];
+    const sourceSentencesOfParagraphs = [];
     for (let i = 0; i < result.size(); i++) {
       translatedParagraphs.push(result.get(i).getTranslatedText());
+      translatedSentencesOfParagraphs.push(getAllTranslatedSentencesOfParagraph(result.get(i)));
+      sourceSentencesOfParagraphs.push(getAllSourceSentencesOfParagraph(result.get(i)));
     }
     console.log({ translatedParagraphs });
+    console.log({ translatedSentencesOfParagraphs });
+    console.log({ sourceSentencesOfParagraphs });
+
     responseOptions.delete();
     input.delete();
     return translatedParagraphs;
+  }
+
+  // This function extracts all the translated sentences from the Response and returns them.
+  const getAllTranslatedSentencesOfParagraph = (response) => {
+    const sentences = [];
+    const text = response.getTranslatedText();
+    for (let sentenceIndex = 0; sentenceIndex < response.size(); sentenceIndex++) {
+      const utf8SentenceByteRange = response.getTranslatedSentence(sentenceIndex);
+      sentences.push(_getSentenceFromByteRange(text, utf8SentenceByteRange));
+    }
+    return sentences;
+  }
+
+  // This function extracts all the source sentences from the Response and returns them.
+  const getAllSourceSentencesOfParagraph = (response) => {
+    const sentences = [];
+    const text = response.getOriginalText();
+    for (let sentenceIndex = 0; sentenceIndex < response.size(); sentenceIndex++) {
+      const utf8SentenceByteRange = response.getSourceSentence(sentenceIndex);
+      sentences.push(_getSentenceFromByteRange(text, utf8SentenceByteRange));
+    }
+    return sentences;
+  }
+
+  // This function returns a substring of text (a string). The substring is represented by
+  // byteRange (begin and end endices) within the utf-8 encoded version of the text.
+  const _getSentenceFromByteRange = (text, byteRange) => {
+    const utf8BytesView = encoder.encode(text);
+    const utf8SentenceBytes = utf8BytesView.subarray(byteRange.begin, byteRange.end);
+    return decoder.decode(utf8SentenceBytes);
   }
 
   document.querySelector("#load").addEventListener("click", async() => {


### PR DESCRIPTION
This PR fixes https://github.com/browsermt/bergamot-translator/issues/57

Details:
- Moved `ByteRange` structure to `definitions.h` file as this is a base structure that is used to represent a sentence, word, token etc.
- Added public methods to return sentence byte ranges from Response class
    - Doesn't make sense to expose an internal structure `AnnotatedText` just for returning this information to JS
- JS bindings to access sentence byte ranges from wasm module
- wasm test page changes to extract individual sentences from response using these newly developed JS bindings