### PR TITLE
Windows workflow: run-vcpkg7.{3->4}; vcpkg master

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -37,10 +37,10 @@ jobs:
       shell: powershell
 
     - name: Prepare vcpkg
-      uses: lukka/run-vcpkg@v7.3
+      uses: lukka/run-vcpkg@v7.4
       with:
         vcpkgArguments: protobuf pcre2
-        vcpkgGitCommitId: 6185aa76504a5025f36754324abf307cc776f3da 
+        vcpkgGitCommitId: 8dddc6c899ce6fdbeab38b525a31e7f23cb2d5bb
         vcpkgDirectory: ${{ github.workspace }}/vcpkg/
         vcpkgTriplet: x64-windows-static
 


### PR DESCRIPTION
A cmake change has caused vcpkg to fail without much error message,
which is causing windows workflow runs to fail. Details in the following
link:

* https://github.com/microsoft/vcpkg/issues/18718

To fix, we're going with a version bump in vcpkg. Seeing that run-vcpkg
also seems to have gotten an update, updating run-vcpkg from 7.3 to 7.4
Playing with fire: vcpkg master commit