### PR TITLE
Add a clang-tidy run

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,32 @@
+Checks: >
+  .*,
+  bugprone-*,  
+  concurrency-*,
+  google-*,
+  portability-*,
+  performance-*,
+  clang-analyzer-*,
+  readability-*,
+  -readability-implicit-bool-conversion,
+  -readability-isolate-declaration,
+  -readability-uppercase-literal-suffix,
+  misc-*,
+  -misc-noexcept*,
+  modernize-*,
+  -modernize-deprecated-headers,
+  -modernize-use-nodiscard,
+  -modernize-raw-string-literal,
+  -modernize-return-braced-init-list,
+  -modernize-use-equals-delete,
+  -modernize-use-trailing-return-type,
+
+
+
+CheckOptions:
+  - { key: readability-identifier-naming.ClassCase,     value: CamelCase  }
+  - { key: readability-identifier-naming.ClassMethodCase, value: camelBack  }
+  - { key: readability-identifier-naming.VariableCase,  value: camelBack  }
+  - { key: readability-identifier-naming.FunctionCase,  value: camelBack  }
+  - { key: readability-identifier-naming.PrivateMemberSuffix,  value: _   }
+  - { key: readability-identifier-naming.ParameterCase, value: camelBack  }
+

--- a/.github/workflows/coding-styles.yml
+++ b/.github/workflows/coding-styles.yml
@@ -1,5 +1,7 @@
 name: "Coding Style"
 
+env:
+    clang_version: 10
 on: 
   push:
     branches: [ main, ci-sandbox ]
@@ -19,8 +21,24 @@ jobs:
         - name: Install dependencies
           run: |
             sudo apt-get update 
-            sudo apt-get install -y clang-format
+            sudo apt-get install -y build-essential cmake
+            sudo apt-get install -y clang-format clang-tidy-${{ env.clang_version }}
 
         - name: Run clang-format
           run:
               python3 run-clang-format.py --style file -r src wasm
+
+
+        - name: Prepare build, compilation database etc.
+          run: |
+              mkdir -p build
+              cd build 
+              cmake \
+                -DUSE_WASM_COMPATIBLE_SOURCE=off -DCMAKE_EXPORT_COMPILE_COMMANDS=on \
+                -DCMAKE_C_COMPILER=clang-${{ env.clang_version }} -DCMAKE_CXX_COMPILER=clang++-${{ env.clang_version }} \
+                ..
+
+        - name: Run clang-tidy
+          run: |
+              run-clang-tidy-${{ env.clang_version }} -p build "$PWD/src/.*"
+              run-clang-tidy-${{ env.clang_version }} -p build "$PWD/app/.*"


### PR DESCRIPTION
Adds a clang-tidy run in addition to the existing clang-format checks.
The clang-tidy checks are not enforced, but is potentially useful to
point to during review.

