### PR TITLE
Wasm build instructions to run translations on other browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,20 +29,32 @@ Building on wasm requires Emscripten toolchain. It can be downloaded and install
 
 #### <a name="Compile"></a> Compile
 
-1. Create a folder where you want to build all the artifacts (`build-wasm` in this case) and compile
-    ```bash
-    mkdir build-wasm
-    cd build-wasm
-    emcmake cmake -DCOMPILE_WASM=on ../
-    emmake make -j2
-    ```
+To build a version that translates with higher speeds on Firefox Nightly browser, follow these instructions:
 
-    The wasm artifacts (.js and .wasm files) will be available in the build directory ("build-wasm" in this case).
+   1. Create a folder where you want to build all the artifacts (`build-wasm` in this case) and compile
+       ```bash
+       mkdir build-wasm
+       cd build-wasm
+       emcmake cmake -DCOMPILE_WASM=on ../
+       emmake make -j2
+       ```
 
-2. Enable SIMD Wormhole via Wasm instantiation API in generated artifacts
-    ```bash
-    bash ../wasm/patch-artifacts-enable-wormhole.sh
-    ```
+       The wasm artifacts (.js and .wasm files) will be available in the build directory ("build-wasm" in this case).
+
+   2. Enable SIMD Wormhole via Wasm instantiation API in generated artifacts
+       ```bash
+       bash ../wasm/patch-artifacts-enable-wormhole.sh
+       ```
+
+To build a version that runs on all browsers (including Firefox Nightly) but translates slowly, follow these instructions:
+
+  1. Create a folder where you want to build all the artifacts (`build-wasm` in this case) and compile
+      ```bash
+      mkdir build-wasm
+      cd build-wasm
+      emcmake cmake -DCOMPILE_WASM=on -DWORMHOLE=off ../
+      emmake make -j2
+      ```
 
 #### Recompiling
 As long as you don't update any submodule, just follow [Compile](#Compile) steps.\


### PR DESCRIPTION
Fixes https://github.com/browsermt/bergamot-translator/issues/206

Updated README to add build instructions for running on other browsers

Tested it on Google Chrome browser (92.0.4515.131 (Official Build) (x86_64)) on Mac OS 11.4