### PR TITLE
Update config "skip-cost" to return log probabilities as QE scores

### DIFF
--- a/wasm/test_page/js/worker.js
+++ b/wasm/test_page/js/worker.js
@@ -176,7 +176,7 @@ max-length-break: 128
 mini-batch-words: 1024
 workspace: 128
 max-length-factor: 2.0
-skip-cost: true
+skip-cost: false
 cpu-threads: 0
 quiet: true
 quiet-translation: true


### PR DESCRIPTION
Setting this config to `false` allows the quality scores to be returned as log-probability values