### PR TITLE
Import optimized gemm implementation (when available) for wasm target

### DIFF
--- a/wasm/import-gemm-module.js
+++ b/wasm/import-gemm-module.js
@@ -1,0 +1,23 @@
+
+/* Use an optimized gemm implementation if available, otherwise use the fallback
+ * implementation.
+ */
+function createWasmGemm() {
+    const OPTIMIZED_GEMM = "mozIntGemm";
+    const FALLBACK_GEMM =  "asm";
+
+    if (WebAssembly[OPTIMIZED_GEMM]) {
+        return new WebAssembly.instance(WebAssembly[OPTIMIZED_GEMM](), {"": {memory: wasmMemory}}).exports;
+    }
+    else {
+        return {
+            "int8_prepare_a": (...a) => Module[FALLBACK_GEMM]["int8PrepareAFallback"](...a),
+            "int8_prepare_b": (...a) => Module[FALLBACK_GEMM]["int8PrepareBFallback"](...a),
+            "int8_prepare_b_from_transposed": (...a) => Module[FALLBACK_GEMM]["int8PrepareBFromTransposedFallback"](...a),
+            "int8_prepare_b_from_quantized_transposed": (...a) => Module[FALLBACK_GEMM]["int8PrepareBFromQuantizedTransposedFallback"](...a),
+            "int8_prepare_bias": (...a) => Module[FALLBACK_GEMM]["int8PrepareBiasFallback"](...a),
+            "int8_multiply_and_add_bias": (...a) => Module[FALLBACK_GEMM]["int8MultiplyAndAddBiasFallback"](...a),
+            "int8_select_columns_of_b": (...a) => Module[FALLBACK_GEMM]["int8SelectColumnsOfBFallback"](...a)
+        }
+    }
+}

--- a/wasm/import-gemm-module.js
+++ b/wasm/import-gemm-module.js
@@ -8,7 +8,7 @@ function createWasmGemm() {
 
     if (WebAssembly[OPTIMIZED_GEMM]) {
         console.log(`Using optimized gemm (${OPTIMIZED_GEMM}) implementation`);
-        return new WebAssembly.instance(WebAssembly[OPTIMIZED_GEMM](), {"": {memory: wasmMemory}}).exports;
+        return new WebAssembly.Instance(WebAssembly[OPTIMIZED_GEMM](), {"": {memory: wasmMemory}}).exports;
     }
     else {
         console.log(`Using fallback gemm implementation`);

--- a/wasm/import-gemm-module.js
+++ b/wasm/import-gemm-module.js
@@ -7,9 +7,11 @@ function createWasmGemm() {
     const FALLBACK_GEMM =  "asm";
 
     if (WebAssembly[OPTIMIZED_GEMM]) {
+        console.log(`Using optimized gemm (${OPTIMIZED_GEMM}) implementation`);
         return new WebAssembly.instance(WebAssembly[OPTIMIZED_GEMM](), {"": {memory: wasmMemory}}).exports;
     }
     else {
+        console.log(`Using fallback gemm implementation`);
         return {
             "int8_prepare_a": (...a) => Module[FALLBACK_GEMM]["int8PrepareAFallback"](...a),
             "int8_prepare_b": (...a) => Module[FALLBACK_GEMM]["int8PrepareBFallback"](...a),

--- a/wasm/patch-artifacts-import-gemm-module.sh
+++ b/wasm/patch-artifacts-import-gemm-module.sh
@@ -30,14 +30,8 @@ if [ ! -e "$ARTIFACT" ]; then
 fi
 
 echo "Importing integer (8-bit) gemm implementation"
+SCRIPT_ABSOLUTE_PATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 sed -i.bak 's/"env"[[:space:]]*:[[:space:]]*asmLibraryArg,/"env": asmLibraryArg,\
-    "wasm_gemm":{\
-    "int8_prepare_a": (...a) => Module["asm"].int8PrepareAFallback(...a),\
-    "int8_prepare_b": (...a) => Module["asm"].int8PrepareBFallback(...a),\
-    "int8_prepare_b_from_transposed": (...a) => Module["asm"].int8PrepareBFromTransposedFallback(...a),\
-    "int8_prepare_b_from_quantized_transposed": (...a) => Module["asm"].int8PrepareBFromQuantizedTransposedFallback(...a),\
-    "int8_prepare_bias": (...a) => Module["asm"].int8PrepareBiasFallback(...a),\
-    "int8_multiply_and_add_bias": (...a) => Module["asm"].int8MultiplyAndAddBiasFallback(...a),\
-    "int8_select_columns_of_b": (...a) => Module["asm"].int8SelectColumnsOfBFallback(...a),\
-    },/g' ${ARTIFACT}
+    "wasm_gemm": createWasmGemm(),/g' ${ARTIFACT}
+cat $SCRIPT_ABSOLUTE_PATH/import-gemm-module.js >> ${ARTIFACT}
 echo "SUCCESS"


### PR DESCRIPTION
Fixes https://github.com/browsermt/bergamot-translator/issues/264

List of changes:
- Added file `wasm/import-gemm-module.js` that houses the logic to import and use the optimized gemm when available, otherwise fallback gemm
- Associated refactoring in `wasm/patch-artifacts-import-gemm-module.sh` for this change

Ran [wasm test page](https://github.com/browsermt/bergamot-translator/tree/main/wasm#demo) to test this logic. The optimized gemm is called when run on locally compiled version of firefox browser that exports a dummy implementation for gemm intrinsics. This proves that the logic written here works correctly to invoke an optimized gemm when available in the environment.

cc @yurydelendik @eqrion