### PR TITLE
HTML handling improvements

### DIFF
--- a/src/tests/units/html_tests.cpp
+++ b/src/tests/units/html_tests.cpp
@@ -413,7 +413,6 @@ TEST_CASE("Test empty self-closing pair at end of input in parent") {
   CHECK(input == "hello ");
 }
 
-
 TEST_CASE("Test empty tag", "[!mayfail]") {
   std::string input(
       "<p id=\"1\">hello <img id=\"1.1\"><span id=\"1.2\"><u id=\"1.2.1\"></u><b id=\"1.2.2\"></b><img "

--- a/src/tests/units/html_tests.cpp
+++ b/src/tests/units/html_tests.cpp
@@ -395,6 +395,25 @@ TEST_CASE("Test self-closing tag (HTML5)") {
   CHECK(input == "hello  world and other creatures\n");  // Note double space between "hello" and "world"
 }
 
+TEST_CASE("Test empty self-closing tag at end of input") {
+  std::string input("hello <br>");
+  HTML html(std::move(input), true);
+  CHECK(input == "hello ");
+}
+
+TEST_CASE("Test empty tag pair at end of input") {
+  std::string input("hello <u></u>");
+  HTML html(std::move(input), true);
+  CHECK(input == "hello ");
+}
+
+TEST_CASE("Test empty self-closing pair at end of input in parent") {
+  std::string input("<p>hello <br></p>");
+  HTML html(std::move(input), true);
+  CHECK(input == "hello ");
+}
+
+
 TEST_CASE("Test empty tag", "[!mayfail]") {
   std::string input(
       "<p id=\"1\">hello <img id=\"1.1\"><span id=\"1.2\"><u id=\"1.2.1\"></u><b id=\"1.2.2\"></b><img "

--- a/src/translator/html.cpp
+++ b/src/translator/html.cpp
@@ -166,6 +166,10 @@ AnnotatedText Apply(AnnotatedText const &in, Fun fun) {
 
 bool IsContinuation(string_view str) { return !str.empty() && str.compare(0, 1, " ", 1) != 0; }
 
+bool HasAlignments(Response const &response) {
+  return !response.alignments.empty() && !response.alignments[0][0].empty();
+}
+
 void HardAlignments(Response const &response, std::vector<std::vector<size_t>> &alignments) {
   // For each sentence...
   for (size_t sentenceIdx = 0; sentenceIdx < response.target.numSentences(); ++sentenceIdx) {
@@ -512,7 +516,7 @@ void HTML::Restore(Response &response) {
   // tokens with the tags from their source token counterpart. If there is no
   // alignment information available, we just interpolate based on sentence
   // length (badly).
-  if (!response.alignments.empty()) {
+  if (HasAlignments(response)) {
     // DebugPrintAlignmentScores(std::cerr, response);
     HardAlignments(response, alignments);
   } else {

--- a/src/translator/html.cpp
+++ b/src/translator/html.cpp
@@ -199,11 +199,11 @@ void HardAlignments(Response const &response, std::vector<std::vector<size_t>> &
         size_t s_max = score_curr > score_prev ? s_curr : s_prev;
 
         // Apply this to all previous tokens in the word
-        for (size_t i = t; i >= 0; --i) {
+        for (size_t i = t;; --i) {
           alignments.back()[i] = s_max;
 
-          // Stop if this was the beginning of the word
-          if (!IsContinuation(response.target.word(sentenceIdx, i))) break;
+          // Stop if this was the first token or the beginning of the word
+          if (i == 0 || !IsContinuation(response.target.word(sentenceIdx, i))) break;
         }
       }
     }


### PR DESCRIPTION
This merge request contains fixes for several issues:

1. If the model did not have `alignment:soft` in its configuration, `HardAlignment()` would crash & burn.
2. If you had a model that cut the first word of an output into multiple tokens, and the first of those tokens was not the token that had the highest alignment score of all target tokens for that word, there was an invalid array access (because `(size_t)0 - 1 >= 0`…)
3. If you had an empty (i.e. what in XHTML was a self-closing) element at the end of a parent's element contents, or the end of a sentence, you'd get a parse error because that empty element would stay on the stack too long.
4. `&nbsp;` was not recognised. It is now, but translated to a single "␣". So if there was a non-breaking space in the source HTML, it will not correctly be reconstructed. If this is a problem, we could treat `&nsbp;` as a special sort of formatting/taint for spaces and handle it that way.
5. This contains a partial fix for losing elements that have no text in them, e.g. `hello <u></u> world`. Previously the `<u></u>` would be lost. Now an empty span is added with the `u` as markup, which then gets opened & closed before `_world`. These empty spans are not yet copied over to the target side, so translated output will still lose empty tags.