### PR TITLE
Updated configuration for html text translation to work in wasm test page

### DIFF
--- a/wasm/test_page/js/worker.js
+++ b/wasm/test_page/js/worker.js
@@ -324,7 +324,7 @@ const _parseTranslatedTextSentenceQualityScores = (vectorResponse) => {
 }
 
 const _prepareResponseOptions = () => {
-  return {qualityScores: true, alignment: false, html: true};
+  return {qualityScores: true, alignment: true, html: true};
 }
 
 const _prepareSourceText = (input) => {

--- a/wasm/test_page/js/worker.js
+++ b/wasm/test_page/js/worker.js
@@ -181,6 +181,7 @@ cpu-threads: 0
 quiet: true
 quiet-translation: true
 gemm-precision: int8shiftAlphaAll
+alignment: soft
 `;
 
   const modelFile = `${rootURL}/${languagePair}/${modelRegistry[languagePair]["model"].name}`;


### PR DESCRIPTION
Added `alignment: soft` during translator construction as per https://github.com/browsermt/bergamot-translator/pull/266#issuecomment-982715697 and `ResponseOptions::alignment` to `true` as per https://github.com/browsermt/bergamot-translator/pull/266#issuecomment-982773699

Both of these changes were required for the html text translation to work. Only providing`alignment: soft` during translator construction and not setting `ResponseOptions::alignment` to `true` doesn't give correct results.