### PR TITLE
Remove value length limit from HTML parser & interpolated alignments

### DIFF
--- a/app/cli.h
+++ b/app/cli.h
@@ -56,6 +56,10 @@ void wasm(const CLIConfig &config) {
       std::make_shared<TranslationModel>(options->asYamlString(), std::move(memoryBundle));
 
   ResponseOptions responseOptions;
+  if (config.html) {
+    responseOptions.HTML = true;
+    responseOptions.alignment = true;  // Necessary for HTML
+  }
   std::vector<std::string> texts;
 
   // Hide the translateMultiple operation
@@ -145,6 +149,10 @@ void native(const CLIConfig &config) {
   std::string input = std_input.str();
 
   ResponseOptions responseOptions;
+  if (config.html) {
+    responseOptions.HTML = true;
+    responseOptions.alignment = true;  // Necessary for HTML
+  }
 
   // Wait on future until Response is complete
   std::promise<Response> responsePromise;

--- a/src/tests/units/CMakeLists.txt
+++ b/src/tests/units/CMakeLists.txt
@@ -3,7 +3,8 @@ set(UNIT_TESTS
     annotation_tests
     cache_tests
     quality_estimator_tests
-    html_tests)
+    html_tests
+    xh_scanner_tests)
 
 foreach(test ${UNIT_TESTS})
   add_executable("run_${test}" run_tests.cpp "${test}.cpp")

--- a/src/tests/units/html_tests.cpp
+++ b/src/tests/units/html_tests.cpp
@@ -233,6 +233,12 @@ TEST_CASE("Test reconstruction of target sentence") {
   Response response;
   response.source = source;
   response.target = target;
+  response.alignments = {{
+      {1.0, 0.0, 0.0, 0.0},
+      {0.0, 1.0, 0.0, 0.0},
+      {0.0, 0.0, 1.0, 0.0},
+      {0.0, 0.0, 0.0, 1.0},
+  }};
 
   html.Restore(response);
 
@@ -274,6 +280,15 @@ TEST_CASE("Test reconstruction of target sentence with entities") {
   Response response;
   response.source = source;
   response.target = target;
+  response.alignments = {{
+      {1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
+      {0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0},
+      {0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0},
+      {0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0},
+      {0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0},
+      {0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0},
+      {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0},
+  }};
 
   html.Restore(response);
 

--- a/src/tests/units/html_tests.cpp
+++ b/src/tests/units/html_tests.cpp
@@ -49,6 +49,16 @@ void RecordSentenceFromByteRange(AnnotatedText &text, std::vector<ByteRange> con
   text.recordExistingSentence(tokens.begin(), tokens.end(), text.text.data() + ranges[0].begin);
 }
 
+template <typename T>
+std::vector<std::vector<T>> identity_matrix(size_t size) {
+  std::vector<std::vector<T>> rows(size);
+  for (size_t row = 0; row < size; ++row) {
+    rows[row].resize(size, T(0));
+    rows[row][row] = T(1);
+  }
+  return rows;
+}
+
 TEST_CASE("Ignore HTML if process_markup is false") {
   std::string html_code("<p>This text &amp; has <b>HTML</b> in it</p>");
 
@@ -59,108 +69,44 @@ TEST_CASE("Ignore HTML if process_markup is false") {
   Response response;
   response.source.text = html_code;
   response.target.text = html_code;
+  // Note: response.alignments is empty, which is allowed in this case
   html.Restore(response);
 
   // Assert that Restore() does not mess with my HTML code
   CHECK(response.source.text == html_code);
 }
 
-TEST_CASE("Test reconstruction") {
-  std::string input("<p><input>H<u>e</u>llo <b>world</b> how <u>are you</u>?</p>\n");
+// TODO: is there a better way to test for correct abort() calls than [!shouldfail]
+TEST_CASE("Abort if alignments are missing") {
+  marian::setThrowExceptionOnAbort(true);
 
-  std::string text(input);
-  HTML html(std::move(text), true);  // TODO: move, but really a reference?
-  CHECK(text == "Hello world how are you?\n");
+  std::string input("<p>hello <b>world</b></p>\n");
+  HTML html(std::move(input), true);
 
-  AnnotatedText source(std::move(text));
-  std::vector<string_view> tokens{
-      string_view(source.text.data() + 0, 4),   // Hell
-      string_view(source.text.data() + 4, 1),   // o
-      string_view(source.text.data() + 5, 6),   // _world
-      string_view(source.text.data() + 11, 4),  // _how
-      string_view(source.text.data() + 15, 4),  // _are
-      string_view(source.text.data() + 19, 4),  // _you
-      string_view(source.text.data() + 23, 1),  // ?
-      string_view(source.text.data() + 24, 0),  // "\n" (but 0 length?)
-  };
+  AnnotatedText source("hello world\n");
+  RecordSentenceFromByteRange(source, {
+                                          ByteRange{0, 4},   // 0.0 "hell"
+                                          ByteRange{4, 5},   // 0.1 "o"
+                                          ByteRange{5, 11},  // 0.2 " world"
+                                          ByteRange{11, 11}  // 0.3 ""
+                                      });
 
-  source.recordExistingSentence(tokens.begin(), tokens.end(), source.text.data());
+  AnnotatedText target("hallo Welt\n");
+  RecordSentenceFromByteRange(target, {
+                                          ByteRange{0, 4},   // 0.0 "hall"
+                                          ByteRange{4, 5},   // 0.1 "o"
+                                          ByteRange{5, 10},  // 0.2 " Welt"
+                                          ByteRange{10, 10}  // 0.3 ""
+                                      });
 
   Response response;
   response.source = source;
+  response.target = target;
+  // Note: explicitly not setting response.alignments
 
-  html.Restore(response);
-  // CHECK(response.source.text == input);  // fails because <u></u> has been moved to the front of the token
-  CHECK(response.source.text == "<p><input><u></u>Hello <b>world</b> how <u>are you</u>?</p>\n");
-
-  std::vector<ByteRange> restored_tokens{
-      ByteRange{0, 0 + 0},    // (start of sentence)
-      ByteRange{0, 0 + 21},   // <p><input>H<u>e</u>ll
-      ByteRange{21, 21 + 1},  // o
-      ByteRange{22, 22 + 9},  // _<b>world
-      ByteRange{31, 31 + 8},  // </b>_how
-      ByteRange{39, 39 + 7},  // _<u>are
-      ByteRange{46, 46 + 4},  // _you
-      ByteRange{50, 50 + 5},  // </u>?
-      ByteRange{55, 55 + 0},  // ""
-      ByteRange{55, 55 + 5},  // </p>\n
-  };
-  CHECK(response.source.text.size() == restored_tokens.back().end);
-  CHECK(AsByteRanges(response.source) == restored_tokens);
-
-  // Same test as above, but easier to read. Will use this further down.
-  std::vector<std::string> restored_tokens_str{"",
-                                               "<p><input><u></u>Hell",  // Should really be "<p><input>H<u>e</u>ll"
-                                               "o",
-                                               " <b>world",
-                                               "</b> how",
-                                               " <u>are",
-                                               " you",
-                                               "</u>?",
-                                               "",  // end of sentence
-                                               "</p>\n"};
-
-  CHECK(AsTokens(response.source) == restored_tokens_str);
-}
-
-TEST_CASE("Test reconstruction of multiple sentences") {
-  std::string input("<p>This <em>is a sentence. And so is</em> this.</p>\n");
-
-  HTML html(std::move(input), true);
-  CHECK(input == "This is a sentence. And so is this.\n");
-
-  Response response;
-  response.source = AnnotatedText(std::move(input));
-
-  RecordSentenceFromByteRange(response.source, {
-                                                   ByteRange{0, 4},    // 0.0 "This"
-                                                   ByteRange{4, 7},    // 0.1 " is"
-                                                   ByteRange{7, 9},    // 0.2 " a"
-                                                   ByteRange{9, 18},   // 0.3 " sentence"
-                                                   ByteRange{18, 19},  // 0.4 "."
-                                               });
-
-  RecordSentenceFromByteRange(response.source, {
-                                                   ByteRange{20, 23},  // 1.0 "And"
-                                                   ByteRange{23, 26},  // 1.1 " so"
-                                                   ByteRange{26, 29},  // 1.2 " is"
-                                                   ByteRange{29, 34},  // 1.3 " this"
-                                                   ByteRange{34, 35},  // 1.4 "."
-                                               });
-
-  std::vector<std::string> tokens{"",    "This", " is", " a",    " sentence", ".", " ",
-                                  "And", " so",  " is", " this", ".",         "\n"};
-
-  CHECK(AsTokens(response.source) == tokens);
-
-  html.Restore(response);
-
-  std::vector<std::string> html_tokens{
-      "",       "<p>This", " <em>is", " a", " sentence", ".", " ", "And", " so", " is", "</em> this", ".",
-      "</p>\n",  // </p> got moved into post-sentence gap
-  };
-
-  CHECK(AsTokens(response.source) == html_tokens);
+  CHECK_THROWS_WITH(
+      html.Restore(response),
+      "Response object does not contain alignments. TranslationModel or ResponseOptions is misconfigured?");
 }
 
 TEST_CASE("Test case html entities") {
@@ -170,36 +116,6 @@ TEST_CASE("Test case html entities") {
   std::string input("<p data-attr=\"&quot;&apos;\">This is a sentence &lt;with&gt; named &amp; entities</p>\n");
   HTML html(std::move(input), true);
   CHECK(input == "This is a sentence <with> named & entities\n");
-
-  Response response;
-  response.source = AnnotatedText(std::move(input));
-
-  RecordSentenceFromByteRange(response.source, {
-                                                   ByteRange{0, 4},    // 0.0 "This"
-                                                   ByteRange{4, 7},    // 0.1 " is"
-                                                   ByteRange{7, 9},    // 0.2 " a"
-                                                   ByteRange{9, 18},   // 0.3 " sentence"
-                                                   ByteRange{18, 20},  // 0.4 " <"
-                                                   ByteRange{20, 24},  // 0.5 "with"
-                                                   ByteRange{24, 25},  // 0.6 ">"
-                                                   ByteRange{25, 31},  // 0.7 " named"
-                                                   ByteRange{31, 33},  // 0.8 " &"
-                                                   ByteRange{33, 42},  // 0.9 " entities"
-                                                   ByteRange{42, 42}   // 0.10 ""
-                                               });
-
-  html.Restore(response);
-
-  std::vector<std::string> html_tokens{"",          "<p data-attr=\"&quot;&apos;\">This",
-                                       " is",       " a",
-                                       " sentence",
-                                       " &lt;",  // Oh trouble! The < is completely 'consumed'
-                                       "with",      "&gt;",
-                                       " named",    " &amp;",
-                                       " entities", "",
-                                       "</p>\n"};
-
-  CHECK(AsTokens(response.source) == html_tokens);
 }
 
 TEST_CASE("Test self-closing tags should be treated as spaces") {
@@ -233,12 +149,7 @@ TEST_CASE("Test reconstruction of target sentence") {
   Response response;
   response.source = source;
   response.target = target;
-  response.alignments = {{
-      {1.0, 0.0, 0.0, 0.0},
-      {0.0, 1.0, 0.0, 0.0},
-      {0.0, 0.0, 1.0, 0.0},
-      {0.0, 0.0, 0.0, 1.0},
-  }};
+  response.alignments = {identity_matrix<float>(4)};
 
   html.Restore(response);
 
@@ -280,15 +191,7 @@ TEST_CASE("Test reconstruction of target sentence with entities") {
   Response response;
   response.source = source;
   response.target = target;
-  response.alignments = {{
-      {1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
-      {0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0},
-      {0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0},
-      {0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0},
-      {0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0},
-      {0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0},
-      {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0},
-  }};
+  response.alignments = {identity_matrix<float>(7)};
 
   html.Restore(response);
 
@@ -375,6 +278,7 @@ TEST_CASE("Test reconstruction of target with multiple sentences") {
   Response response;
   response.source = source;
   response.target = target;
+  response.alignments = {identity_matrix<float>(5), identity_matrix<float>(10), identity_matrix<float>(5)};
   html.Restore(response);
 
   std::vector<std::string> html_tokens_source{"",
@@ -429,9 +333,11 @@ TEST_CASE("Test empty self-closing pair at end of input in parent") {
 }
 
 TEST_CASE("Test empty tag", "[!mayfail]") {
-  std::string input(
+  std::string test_str(
       "<p id=\"1\">hello <img id=\"1.1\"><span id=\"1.2\"><u id=\"1.2.1\"></u><b id=\"1.2.2\"></b><img "
       "id=\"1.2.3\">world</span></p>\n");
+
+  std::string input(test_str);
   HTML html(std::move(input), true);
   CHECK(input == "hello world\n");
 
@@ -447,10 +353,14 @@ TEST_CASE("Test empty tag", "[!mayfail]") {
   response.source.appendSentence("", sentence.begin(), sentence.end());
   response.source.appendEndingWhitespace("\n");
 
+  response.target.appendSentence("", sentence.begin(), sentence.end());
+  response.target.appendEndingWhitespace("\n");
+
+  response.alignments = {identity_matrix<float>(4)};
+
   html.Restore(response);
-  CHECK(response.source.text ==
-        "<p id=\"1\">hello <img id=\"1.1\"><span id=\"1.2\"><u id=\"1.2.1\"></u><b id=\"1.2.2\"></b><img "
-        "id=\"1.2.3\">world</span></p>\n");
+  CHECK(response.source.text == test_str);
+  CHECK(response.target.text == test_str);
 }
 
 TEST_CASE("End-to-end translation") {

--- a/src/tests/units/html_tests.cpp
+++ b/src/tests/units/html_tests.cpp
@@ -109,6 +109,28 @@ TEST_CASE("Abort if alignments are missing") {
       "Response object does not contain alignments. TranslationModel or ResponseOptions is misconfigured?");
 }
 
+TEST_CASE("Do not abort if the input is just empty") {
+  std::string input("");
+  HTML html(std::move(input), true);
+  CHECK(input == "");
+
+  Response response;
+  html.Restore(response);
+  CHECK(response.source.text == "");
+  CHECK(response.target.text == "");
+}
+
+TEST_CASE("Do not abort if the input is just empty element") {
+  std::string input("<p></p>");
+  HTML html(std::move(input), true);
+  CHECK(input == "");
+
+  Response response;
+  html.Restore(response);
+  CHECK(response.source.text == "<p></p>");
+  CHECK(response.target.text == "");  // Should be <p></p> but hey not there yet.
+}
+
 TEST_CASE("Test case html entities") {
   // These are all entities I would expect in innerHTML, since all other entities
   // can be encoded as UTF-8 so there's no need to encode them through &...; when

--- a/src/tests/units/xh_scanner_tests.cpp
+++ b/src/tests/units/xh_scanner_tests.cpp
@@ -1,0 +1,125 @@
+#include <string>
+
+#include "catch.hpp"
+#include "translator/xh_scanner.h"
+
+TEST_CASE("scan element with attributes") {
+  markup::instream in("<div id=\"test\" class=\"a b c \" hidden>");
+  markup::scanner scanner(in);
+
+  CHECK(scanner.next_token() == markup::scanner::TT_TAG_START);
+  CHECK(scanner.tag_name() == "div");
+  CHECK(scanner.next_token() == markup::scanner::TT_ATTR);
+  CHECK(scanner.attr_name() == "id");
+  CHECK(scanner.value() == "test");
+
+  CHECK(scanner.next_token() == markup::scanner::TT_ATTR);
+  CHECK(scanner.attr_name() == "class");
+  CHECK(scanner.value() == "a b c ");
+
+  CHECK(scanner.next_token() == markup::scanner::TT_ATTR);
+  CHECK(scanner.attr_name() == "hidden");
+  CHECK(scanner.value() == "");
+
+  CHECK(scanner.next_token() == markup::scanner::TT_EOF);
+}
+
+TEST_CASE("scan element with text") {
+  markup::instream in("<span>Hello world</span>");
+  markup::scanner scanner(in);
+
+  CHECK(scanner.next_token() == markup::scanner::TT_TAG_START);
+  CHECK(scanner.next_token() == markup::scanner::TT_TEXT);
+  CHECK(scanner.value() == "Hello world");
+  CHECK(scanner.next_token() == markup::scanner::TT_TAG_END);
+  CHECK(scanner.next_token() == markup::scanner::TT_EOF);
+}
+
+TEST_CASE("scan html entities") {
+  markup::instream in("Hello &amp; &apos;world&apos;");
+  markup::scanner scanner(in);
+
+  CHECK(scanner.next_token() == markup::scanner::TT_TEXT);
+  CHECK(scanner.value() == "Hello ");
+  CHECK(scanner.next_token() == markup::scanner::TT_TEXT);
+  CHECK(scanner.value() == "&");
+  CHECK(scanner.next_token() == markup::scanner::TT_TEXT);
+  CHECK(scanner.value() == " ");
+  CHECK(scanner.next_token() == markup::scanner::TT_TEXT);
+  CHECK(scanner.value() == "'");
+  CHECK(scanner.next_token() == markup::scanner::TT_TEXT);
+  CHECK(scanner.value() == "world");
+  CHECK(scanner.next_token() == markup::scanner::TT_TEXT);
+  CHECK(scanner.value() == "'");
+  CHECK(scanner.next_token() == markup::scanner::TT_EOF);
+}
+
+TEST_CASE("scan nested elements") {
+  markup::instream in("<div><p><img></p></div>");
+  markup::scanner scanner(in);
+
+  CHECK(scanner.next_token() == markup::scanner::TT_TAG_START);
+  CHECK(scanner.tag_name() == "div");
+  CHECK(scanner.next_token() == markup::scanner::TT_TAG_START);
+  CHECK(scanner.tag_name() == "p");
+  CHECK(scanner.next_token() == markup::scanner::TT_TAG_START);
+  CHECK(scanner.tag_name() == "img");
+  CHECK(scanner.next_token() == markup::scanner::TT_TAG_END);
+  CHECK(scanner.tag_name() == "p");
+  CHECK(scanner.next_token() == markup::scanner::TT_TAG_END);
+  CHECK(scanner.tag_name() == "div");
+  CHECK(scanner.next_token() == markup::scanner::TT_EOF);
+}
+
+TEST_CASE("scan kitchen sink") {
+  std::string html_str =
+      "<div id=\"test-id\" class=\"a b c \">\n"
+      "<span x-custom-attribute=\"Hello &quot;world&quot;\"><!--\n"
+      "this is a comment -->this is &amp; text\n"
+      "</span></div>";
+  markup::instream in(html_str.data());
+  markup::scanner scanner(in);
+
+  CHECK(scanner.next_token() == markup::scanner::TT_TAG_START);
+  CHECK(scanner.tag_name() == "div");
+  CHECK(scanner.next_token() == markup::scanner::TT_ATTR);
+  CHECK(scanner.attr_name() == "id");
+  CHECK(scanner.value() == "test-id");
+  CHECK(scanner.next_token() == markup::scanner::TT_ATTR);
+  CHECK(scanner.attr_name() == "class");
+  CHECK(scanner.value() == "a b c ");
+  CHECK(scanner.next_token() == markup::scanner::TT_TEXT);
+  CHECK(scanner.value() == "\n");
+  CHECK(scanner.next_token() == markup::scanner::TT_TAG_START);
+  CHECK(scanner.tag_name() == "span");
+  CHECK(scanner.next_token() == markup::scanner::TT_ATTR);
+  CHECK(scanner.attr_name() == "x-custom-attribute");
+  CHECK(scanner.value() == "Hello &quot;world&quot;");  // We do not decode entities in attributes
+  CHECK(scanner.next_token() == markup::scanner::TT_COMMENT_START);
+  CHECK(scanner.next_token() == markup::scanner::TT_DATA);
+  CHECK(scanner.value() == "\nthis is a comment ");
+  CHECK(scanner.next_token() == markup::scanner::TT_COMMENT_END);
+  CHECK(scanner.next_token() == markup::scanner::TT_TEXT);
+  CHECK(scanner.value() == "this is ");
+  CHECK(scanner.next_token() == markup::scanner::TT_TEXT);
+  CHECK(scanner.value() == "&");
+  CHECK(scanner.next_token() == markup::scanner::TT_TEXT);
+  CHECK(scanner.value() == " text\n");
+  CHECK(scanner.next_token() == markup::scanner::TT_TAG_END);
+  CHECK(scanner.tag_name() == "span");
+  CHECK(scanner.next_token() == markup::scanner::TT_TAG_END);
+  CHECK(scanner.tag_name() == "div");
+  CHECK(scanner.next_token() == markup::scanner::TT_EOF);
+}
+
+TEST_CASE("test long text (#273)") {
+  std::string test_str;
+  for (size_t i = 0; i < 1024; ++i) test_str.append("testing ");
+
+  markup::instream in(test_str.data());
+  markup::scanner scanner(in);
+
+  CHECK(scanner.next_token() == markup::scanner::TT_TEXT);
+  CHECK(scanner.value() == test_str);
+  CHECK(scanner.next_token() == markup::scanner::TT_EOF);
+}

--- a/src/translator/html.cpp
+++ b/src/translator/html.cpp
@@ -171,7 +171,14 @@ AnnotatedText Apply(AnnotatedText const &in, Fun fun) {
 bool IsContinuation(string_view str) { return !str.empty() && str.compare(0, 1, " ", 1) != 0; }
 
 bool HasAlignments(Response const &response) {
-  return !response.alignments.empty() && !response.alignments[0][0].empty();
+  // Test for each sentence individually as a sentence may be empty (or there)
+  // might be no sentences, so just testing for alignments.empty() would not be
+  // sufficient.
+  for (size_t sentenceIdx = 0; sentenceIdx < response.target.numSentences(); ++sentenceIdx)
+    if (response.alignments.size() <= sentenceIdx ||
+        response.alignments[sentenceIdx].size() != response.target.numWords(sentenceIdx))
+      return false;
+  return true;
 }
 
 void HardAlignments(Response const &response, std::vector<std::vector<size_t>> &alignments) {

--- a/src/translator/html.cpp
+++ b/src/translator/html.cpp
@@ -178,12 +178,13 @@ void HardAlignments(Response const &response, std::vector<std::vector<size_t>> &
   // For each sentence...
   for (size_t sentenceIdx = 0; sentenceIdx < response.target.numSentences(); ++sentenceIdx) {
     alignments.emplace_back();
-    assert(response.alignments[sentenceIdx].size() == response.target.numWords(sentenceIdx));
 
     // Hard-align: find for each target token the most prevalent source token
-    for (size_t t = 0; t < response.alignments[sentenceIdx].size(); ++t) {
+    // Note: only search from 0 to N-1 because token N is end-of-sentence token
+    // that can only align with the end-of-sentence token of the target
+    for (size_t t = 0; t + 1 < response.target.numWords(sentenceIdx); ++t) {
       size_t s_max = 0;
-      for (size_t s = 1; s < response.alignments[sentenceIdx][t].size(); ++s) {
+      for (size_t s = 1; s + 1 < response.source.numWords(sentenceIdx); ++s) {
         if (response.alignments[sentenceIdx][t][s] > response.alignments[sentenceIdx][t][s_max]) {
           s_max = s;
         }
@@ -193,10 +194,10 @@ void HardAlignments(Response const &response, std::vector<std::vector<size_t>> &
     }
 
     // Next, we try to smooth out these selected alignments with a few heuristics
-    for (size_t t = 0; t < response.target.numWords(sentenceIdx); ++t) {
+    for (size_t t = 1; t + 1 < response.target.numWords(sentenceIdx); ++t) {
       // If this token is a continuation of a previous token, pick the tags from the most
       // prevalent token for the whole word.
-      if (t > 0 && IsContinuation(response.target.word(sentenceIdx, t))) {
+      if (IsContinuation(response.target.word(sentenceIdx, t))) {
         // Note: only looking at the previous token since that will already
         // have this treatment applied to it.
         size_t s_curr = alignments.back()[t];
@@ -204,30 +205,22 @@ void HardAlignments(Response const &response, std::vector<std::vector<size_t>> &
         float score_curr = response.alignments[sentenceIdx][t][s_curr];
         float score_prev = response.alignments[sentenceIdx][t - 1][s_prev];
 
-        size_t s_max = score_curr > score_prev ? s_curr : s_prev;
+        if (score_curr > score_prev) {
+          // Apply this to all previous tokens in the word
+          for (size_t i = t;; --i) {
+            alignments.back()[i] = s_curr;
 
-        // Apply this to all previous tokens in the word
-        for (size_t i = t;; --i) {
-          alignments.back()[i] = s_max;
-
-          // Stop if this was the first token or the beginning of the word
-          if (i == 0 || !IsContinuation(response.target.word(sentenceIdx, i))) break;
+            // Stop if this was the first token or the beginning of the word
+            if (i == 0 || !IsContinuation(response.target.word(sentenceIdx, i))) break;
+          }
+        } else {
+          alignments.back()[t] = s_prev;
         }
       }
     }
-  }
-}
 
-void InterpolateAlignments(Response const &response, std::vector<std::vector<size_t>> &alignments) {
-  for (size_t sentenceIdx = 0; sentenceIdx < response.target.numSentences(); ++sentenceIdx) {
-    alignments.emplace_back();
-    double ratio = (double)response.source.numWords(sentenceIdx) / response.target.numWords(sentenceIdx);
-
-    for (size_t wordIdx = 0; wordIdx < response.target.numWords(sentenceIdx); ++wordIdx) {
-      size_t source_token_idx = static_cast<size_t>(ratio * wordIdx);
-      assert(source_token_idx < response.source.numWords(sentenceIdx));
-      alignments.back().push_back(source_token_idx);
-    }
+    // Always align target end with source end
+    alignments.back().push_back(response.source.numWords(sentenceIdx) - 1);
   }
 }
 
@@ -468,10 +461,13 @@ HTML::HTML(std::string &&source, bool process_markup) {
         // separate words
         if (IsBlockElement(scanner.get_tag_name()) && !source.empty() && source.back() != ' ') source.push_back(' ');
 
-        tag = new Tag{scanner.get_tag_name(), std::string(), IsEmptyElement(scanner.get_tag_name())};
-        pool_.emplace_back(tag);  // pool_ takes ownership of our tag
+        // pool_ takes ownership of our tag, makes sure it's freed when necessary
+        pool_.emplace_back(new Tag{scanner.get_tag_name(), std::string(), IsEmptyElement(scanner.get_tag_name())});
 
-        stack.push_back(pool_.back().get());
+        // Tag *tag is used by attribute parsing
+        tag = pool_.back().get();
+
+        stack.push_back(tag);
 
         // Empty elements (e.g. <img>) are not applicable to a span of text
         // so instead we "apply" them to an empty span in between, and then
@@ -480,7 +476,6 @@ HTML::HTML(std::string &&source, bool process_markup) {
           spans_.push_back(Span{source.size(), source.size(), stack});
           stack.pop_back();
         }
-
         break;
 
       case markup::scanner::TT_TAG_END:
@@ -494,7 +489,7 @@ HTML::HTML(std::string &&source, bool process_markup) {
 
         // What to do with "<u></u>" case, where tag is immediately closed
         // so it never makes it into the taint of any of the spans? This adds
-        // an empty span so it still lives.
+        // an empty span so it still gets recorded in spans_.
         if (spans_.empty() || !ContainsTag(spans_.back().tags, stack.back()))
           spans_.push_back(Span{source.size(), source.size(), stack});
 
@@ -502,6 +497,7 @@ HTML::HTML(std::string &&source, bool process_markup) {
         break;
 
       case markup::scanner::TT_ATTR:
+        assert(tag != nullptr);
         tag->attributes += format(" {}=\"{}\"", scanner.get_attr_name(), scanner.get_value());
         break;
 
@@ -533,19 +529,16 @@ void HTML::Restore(Response &response) {
   AnnotatedText source = RestoreSource(response.source, token_tags, spans_.cbegin(), spans_.cend());
   assert(token_tags.size() == DebugCountTokens(response.source));
 
+  // We need alignment info to transfer the HTML tags from the input to the
+  // translation. If those are not available, no HTML in translations for you.
+  if (!HasAlignments(response)) {
+    response.source = source;
+    return;
+  }
+
   // Find for every token in target the token in source that best matches.
   std::vector<std::vector<size_t>> alignments;
-
-  // If we do have alignment information from the model, we use that to taint
-  // tokens with the tags from their source token counterpart. If there is no
-  // alignment information available, we just interpolate based on sentence
-  // length (badly).
-  if (HasAlignments(response)) {
-    // DebugPrintAlignmentScores(std::cerr, response);
-    HardAlignments(response, alignments);
-  } else {
-    InterpolateAlignments(response, alignments);
-  }
+  HardAlignments(response, alignments);
 
   std::vector<Taint> token_tags_target;
   token_tags_target.emplace_back();  // add empty one to the beginning for easy

--- a/src/translator/parser.cpp
+++ b/src/translator/parser.cpp
@@ -90,6 +90,8 @@ void ConfigParser::addOptionsBoundToConfig(CLI::App &app, CLIConfig &config) {
   app_.add_option("--cache-size", config.cacheSize, "Number of entries to store in cache.");
   app_.add_option("--cache-mutex-buckets", config.cacheMutexBuckets,
                   "Number of mutex buckets to control locking granularity");
+
+  app_.add_flag("--html", config.html, "Whether input and output should be HTML");
 }
 
 std::shared_ptr<marian::Options> parseOptionsFromFilePath(const std::string &configPath, bool validate /*= true*/) {

--- a/src/translator/parser.h
+++ b/src/translator/parser.h
@@ -36,6 +36,7 @@ struct CLIConfig {
   ModelConfigPaths modelConfigPaths;
   bool byteArray;
   bool validateByteArray;
+  bool html;
   size_t numWorkers;
   OpMode opMode;
 

--- a/src/translator/xh_scanner.cpp
+++ b/src/translator/xh_scanner.cpp
@@ -11,10 +11,10 @@ namespace {
 
 // Simple replacement for str.ends_with(compile-time C string)
 template <typename Char_t, size_t Len>
-inline bool ends_with(std::string const &str, const Char_t (&suffix)[Len]) {
+inline bool ends_with(markup::string_view &str, const Char_t (&suffix)[Len]) {
   size_t offset;
-  return __builtin_sub_overflow(str.size(), Len - 1, &offset) == 0 &&
-         std::memcmp(str.data() + offset, suffix, Len - 1) == 0;
+  return __builtin_sub_overflow(str.size, Len - 1, &offset) == 0 &&
+         std::memcmp(str.data + offset, suffix, Len - 1) == 0;
 }
 
 inline bool equals_case_insensitive(const char *lhs, const char *rhs, size_t len) {
@@ -29,8 +29,13 @@ inline bool equals_case_insensitive(const char *lhs, const char *rhs, size_t len
 
 // Alias for the above, but with compile-time known C string
 template <size_t Len>
-inline bool equals_case_insensitive(std::string const &lhs, const char (&rhs)[Len]) {
-  return lhs.size() == Len - 1 && equals_case_insensitive(lhs.data(), rhs, Len);
+inline bool equals_case_insensitive(markup::string_view &lhs, const char (&rhs)[Len]) {
+  return lhs.size == Len - 1 && equals_case_insensitive(lhs.data, rhs, Len);
+}
+
+template <typename Char_t, size_t Len>
+bool operator==(markup::string_view const &str, const Char_t (&str2)[Len]) {
+  return str.size == Len - 1 && std::memcmp(str.data, str2, Len - 1) == 0;
 }
 
 }  // end namespace
@@ -39,280 +44,255 @@ namespace markup {
 
 // case sensitive string equality test
 // s_lowcase shall be lowercase string
-std::string const &scanner::get_value() const { return value_; }
+string_view scanner::value() const { return value_; }
 
-std::string const &scanner::get_attr_name() const { return attr_name_; }
+string_view scanner::attr_name() const { return attr_name_; }
 
-std::string const &scanner::get_tag_name() const { return tag_name_; }
+string_view scanner::tag_name() const { return tag_name_; }
 
 scanner::token_type scanner::scan_body() {
-  text_begin = input.p;
-  if (input_char) {
-    --text_begin;
-  }
-  text_end = text_begin;
-  value_.clear();
-  char c = get_char();
+  value_ = string_view{input_.pos(), 0};
 
-  if (c == 0)
-    return TT_EOF;
-  else if (c == '<')
-    return scan_tag();
-  else if (c == '&')
-    return scan_entity();
+  switch (input_.peek()) {
+    case '\0':
+      return TT_EOF;
+    case '<':
+      return scan_tag();
+    case '&':
+      return scan_entity(TT_TEXT);
+  }
 
   while (true) {
-    value_.push_back(c);
-    ++text_end;
-
-    c = get_char();
-
-    if (c == 0) {
-      push_back(c);
-      break;
-    }
-    if (c == '<') {
-      push_back(c);
-      break;
-    }
-    if (c == '&') {
-      push_back(c);
-      break;
-    }
-  }
-  return TT_TEXT;
-}
-
-scanner::token_type scanner::scan_head() {
-  char c = skip_whitespace();
-
-  if (c == '>') {
-    if (equals_case_insensitive(tag_name_, "script")) {
-      // script is special because we want to parse the attributes,
-      // but not the content
-      c_scan = &scanner::scan_special;
-      return scan_special();
-    } else if (equals_case_insensitive(tag_name_, "style")) {
-      // same with style
-      c_scan = &scanner::scan_special;
-      return scan_special();
-    }
-    c_scan = &scanner::scan_body;
-    return scan_body();
-  }
-  if (c == '/') {
-    char t = get_char();
-    if (t == '>') {
-      // self closing tag
-      c_scan = &scanner::scan_body;
-      return TT_TAG_END;
-    } else {
-      push_back(t);
-      return TT_ERROR;
-    }  // erroneous situtation - standalone '/'
-  }
-
-  attr_name_.clear();
-  value_.clear();
-
-  // attribute name...
-  while (c != '=') {
-    if (c == 0) return TT_EOF;
-    if (c == '>') {
-      push_back(c);
-      return TT_ATTR;
-    }  // attribute without value (HTML style)
-    if (is_whitespace(c)) {
-      c = skip_whitespace();
-      if (c != '=') {
-        push_back(c);
-        return TT_ATTR;
-      }  // attribute without value (HTML style)
-      else
+    switch (input_.peek()) {
+      case '\0':
+      case '<':
+      case '&':
+        return TT_TEXT;
+      default:
+        input_.consume();
+        ++value_.size;
         break;
     }
-    if (c == '<') return TT_ERROR;
-    attr_name_.push_back(c);
-    c = get_char();
+  }
+}
+
+// Consumes one or closing bit of a tag:
+//   <tag attr="value">...</tag>
+//       |------------|
+// Followed by:
+// - scan_special if <script> or <style>
+// - scan_body
+// - another scan_head for the next attribute or end of open tag
+// Returns:
+// - TT_ATTR if attribute is read
+// - TT_TAG_END if self-closing tag
+// - TT_ERROR if wrong character encountered
+// - TT_EOF if unexpected end of input (will not return TT_ATTR if attribute value wasn't finished yet)
+// - TT_TAG_END through scan_special
+// - TT_TEXT through scan_body
+scanner::token_type scanner::scan_attr() {
+  // Skip all whitespace between tag name or last attribute and next attribute or '>'
+  skip_whitespace();
+
+  // Find end of tag name
+  switch (input_.peek()) {
+    case '>':
+      input_.consume();
+      if (equals_case_insensitive(tag_name_, "script")) {
+        // script is special because we want to parse the attributes,
+        // but not the content
+        c_scan = &scanner::scan_special;
+        return scan_special();
+      } else if (equals_case_insensitive(tag_name_, "style")) {
+        // same with style
+        c_scan = &scanner::scan_special;
+        return scan_special();
+      } else {
+        c_scan = &scanner::scan_body;
+        return scan_body();
+      }
+    case '/':
+      input_.consume();
+      if (input_.peek() == '>') {
+        // self closing tag
+        input_.consume();
+        c_scan = &scanner::scan_body;
+        return TT_TAG_END;
+      } else {
+        return TT_ERROR;
+      }
   }
 
-  c = skip_whitespace();
+  attr_name_ = string_view{input_.pos(), 0};
+  value_ = string_view{nullptr, 0};
+
+  // attribute name...
+  while (input_.peek() != '=') {
+    switch (input_.peek()) {
+      case '\0':
+        return TT_EOF;
+      case '>':
+        return TT_ATTR;  // attribute without value (HTML style)
+      case '<':
+        return TT_ERROR;
+      default:
+        if (skip_whitespace()) continue;
+        input_.consume();
+        ++attr_name_.size;
+        break;
+    }
+  }
+
+  // consume '=' and any following whitespace
+  input_.consume();
+  skip_whitespace();
   // attribute value...
 
-  if (c == '\"') {
-    c = get_char();
-    while (c) {
-      if (c == '\"') return TT_ATTR;
-      // if (c == '&') c = scan_entity();
-      value_.push_back(c);
-      c = get_char();
-    }
-  } else if (c == '\'')  // allowed in html
-  {
-    c = get_char();
-    while (c) {
-      if (c == '\'') return TT_ATTR;
-      // if (c == '&') c = scan_entity();
-      value_.push_back(c);
-      c = get_char();
-    }
-  } else  // scan token, allowed in html: e.g. align=center
-  {
-    c = get_char();
-    do {
-      if (is_whitespace(c)) return TT_ATTR;
-      /* these two removed in favour of better html support:
-      if( c == '/' || c == '>' ) { push_back(c); return TT_ATTR; }
-      if( c == '&' ) c = scan_entity();*/
-      if (c == '>') {
-        push_back(c);
-        return TT_ATTR;
+  char quote;  // Either '"' or '\'' depending on which quote we're searching for
+  switch (input_.peek()) {
+    case '"':
+    case '\'':
+      quote = input_.consume();
+      value_ = string_view{input_.pos(), 0};
+      while (true) {
+        if (input_.peek() == '\0') {
+          return TT_ERROR;
+        } else if (input_.peek() == quote) {
+          input_.consume();
+          return TT_ATTR;
+        } else {
+          input_.consume();
+          ++value_.size;
+        }
       }
-      value_.push_back(c);
-      c = get_char();
-    } while (c);
+      break;
+    default:
+      value_ = string_view{input_.pos(), 0};
+
+      while (true) {
+        if (is_whitespace(input_.peek())) return TT_ATTR;
+        if (input_.peek() == '>') return TT_ATTR;  // '>' will be consumed next round
+        input_.consume();
+        ++value_.size;
+      }
+      break;
   }
 
+  // How did we end up here?!
   return TT_ERROR;
 }
 
-// caller already consumed '<'
-// scan header start or tag tail
+// scans tag name of open or closing tag
+//   <tag attr="value">...</tag>
+//   |--|                 |----|
+// Emits:
+// - TT_TAG_START if tag head is read
+// - TT_COMMENT_START
+// - TT_CDATA_START
+// - TT_ENTITY_START
+// - TT_ERROR if unexpected character or end
 scanner::token_type scanner::scan_tag() {
-  tag_name_.clear();
+  if (input_.consume() != '<') return TT_ERROR;
 
-  char c = get_char();
+  bool is_tail = input_.peek() == '/';
+  if (is_tail) input_.consume();
 
-  bool is_tail = c == '/';
-  if (is_tail) c = get_char();
+  tag_name_ = string_view{input_.pos(), 0};
 
-  while (c) {
-    if (is_whitespace(c)) {
-      c = skip_whitespace();
-      break;
-    }
+  while (input_.peek()) {
+    if (skip_whitespace()) break;
 
-    if (c == '/' || c == '>') break;
+    if (input_.peek() == '/' || input_.peek() == '>') break;
 
-    tag_name_.push_back(c);
+    input_.consume();
+    ++tag_name_.size;
 
     if (tag_name_ == "!--") {
       c_scan = &scanner::scan_comment;
       return TT_COMMENT_START;
     }
-
-    if (tag_name_ == "![CDATA[") {
-      c_scan = &scanner::scan_cdata;
-      return TT_CDATA_START;
-    }
-
-    if (tag_name_ == "!ENTITY") {
-      c_scan = &scanner::scan_entity_decl;
-      return TT_ENTITY_START;
-    }
-
-    c = get_char();
   }
 
-  if (c == 0) return TT_ERROR;
+  if (!input_.peek()) return TT_EOF;
 
-  if (is_tail) return c == '>' ? TT_TAG_END : TT_ERROR;
+  if (is_tail) return input_.consume() == '>' ? TT_TAG_END : TT_ERROR;
 
-  push_back(c);
-  c_scan = &scanner::scan_head;
+  c_scan = &scanner::scan_attr;
   return TT_TAG_START;
 }
 
-scanner::token_type scanner::scan_entity() {
-  // note that when scan_entity() is called, & is already consumed.
-
-  std::string buffer;
-  buffer.clear();
-  buffer.push_back('&');  // (just makes resolve_entity and value_.append(buffer) easier)
-
+scanner::token_type scanner::scan_entity(token_type parent_token_type) {
+  // `entity` includes starting '&' and ending ';'
+  string_view entity{input_.pos(), 0};
   bool has_end = false;
 
-  while (true) {
-    char c = get_char();
-    buffer.push_back(c);
+  if (input_.consume() != '&') return TT_ERROR;
 
-    // Found end of entity
-    if (c == ';') break;
+  ++entity.size;  // Account for the consumed '&'
 
-    // Too long to be entity
-    if (buffer.size() == MAX_ENTITY_SIZE) break;
-
-    // Not a character we'd expect in an entity (esp '&' or '<')
-    if (!isalpha(c)) break;
+  // Consume the entity
+  while (input_.peek()) {
+    if (input_.peek() == ';') {
+      input_.consume();
+      ++entity.size;
+      has_end = true;
+      break;
+    } else if (!isalpha(input_.peek())) {
+      has_end = false;
+      break;
+    } else {
+      input_.consume();
+      ++entity.size;
+    }
   }
 
-  // Keep the text_end that scanner::scan_body uses similarly up-to-date. Since
-  // scan_entity() is only called from scan_body we assume text_begin is already
-  // set correctly by it.
-  text_end += buffer.size();
+  // If we can decode the entity, do so
+  if (has_end && resolve_entity(entity, value_)) return parent_token_type;
 
-  // If we found the end of the entity, and we can identify it, then
-  // resolve_entity() will emit the char it encoded.
-  if (buffer.back() == ';' && resolve_entity(buffer)) return TT_TEXT;
-
-  // Otherwise, we just emit whatever we read as text, except for the last
-  // character that caused us to break. That may be another &, or a <, which we
-  // would want to scan properly.
-  value_.append(buffer.data(), buffer.size() - 1);
-  push_back(buffer.back());
-  --text_end;  // because push_back()
-  return TT_TEXT;
+  // Otherwise, just yield the whole thing undecoded, interpret it as text
+  value_ = entity;
+  return parent_token_type;
 }
 
-bool scanner::resolve_entity(std::string const &buffer) {
+bool scanner::resolve_entity(string_view const &buffer, string_view &decoded) const {
+  static char lt = '<', gt = '>', amp = '&', quot = '"', apos = '\'', nbsp = ' ';
+
   if (buffer == "&lt;") {
-    value_.push_back('<');
+    decoded = string_view{&lt, 1};
     return true;
   }
   if (buffer == "&gt;") {
-    value_.push_back('>');
+    decoded = string_view{&gt, 1};
     return true;
   }
   if (buffer == "&amp;") {
-    value_.push_back('&');
+    decoded = string_view{&amp, 1};
     return true;
   }
   if (buffer == "&quot;") {
-    value_.push_back('"');
+    decoded = string_view{&quot, 1};
     return true;
   }
   if (buffer == "&apos;") {
-    value_.push_back('\'');
+    decoded = string_view{&apos, 1};
     return true;
   }
   if (buffer == "&nbsp;") {
-    value_.push_back(' ');  // TODO: handle non-breaking spaces better than just converting them to spaces
+    decoded = string_view{&nbsp, 1};  // TODO: handle non-breaking spaces better than just converting them to spaces
     return true;
   }
   return false;
 }
 
 // skip whitespaces.
-// returns first non-whitespace char
-char scanner::skip_whitespace() {
-  while (char c = get_char()) {
-    if (!is_whitespace(c)) return c;
+// returns how many whitespaces were skipped
+size_t scanner::skip_whitespace() {
+  size_t skipped = 0;
+  while (is_whitespace(input_.peek())) {
+    input_.consume();
+    ++skipped;
   }
-  return 0;
-}
-
-void scanner::push_back(char c) {
-  assert(input_char == 0);
-  input_char = c;
-}
-
-char scanner::get_char() {
-  if (input_char) {
-    char t(input_char);
-    input_char = 0;
-    return t;
-  }
-  return input.get_char();
+  return skipped;
 }
 
 bool scanner::is_whitespace(char c) {
@@ -325,15 +305,16 @@ scanner::token_type scanner::scan_comment() {
     got_tail = false;
     return TT_COMMENT_END;
   }
-  value_.clear();
+
+  value_ = string_view{input_.pos(), 0};
+
   while (true) {
-    char c = get_char();
-    if (c == 0) return TT_EOF;
-    value_.push_back(c);
+    if (input_.consume() == '\0') return TT_EOF;
+    ++value_.size;
 
     if (ends_with(value_, "-->")) {
       got_tail = true;
-      value_.erase(value_.end() - 3);
+      value_.size -= 3;
       break;
     }
   }
@@ -346,91 +327,30 @@ scanner::token_type scanner::scan_special() {
     got_tail = false;
     return TT_TAG_END;
   }
-  value_.clear();
-  while (true) {
-    char c = get_char();
-    if (c == 0) return TT_EOF;
 
-    value_.push_back(c);
+  value_ = string_view{input_.pos(), 0};
+
+  while (true) {
+    if (input_.consume() == '\0') return TT_EOF;
+    ++value_.size;
 
     // Test for </tag>
-    if (c == '>' && value_.size() >= tag_name_.size() + 3) {
+    // TODO: no whitespaces allowed? Is that okay?
+    if (value_.back() == '>' && value_.size >= tag_name_.size + 3) {
       // Test for the "</"" bit of "</tag>"
-      size_t pos_tag_start = value_.size() - tag_name_.size() - 3;
-      if (std::memcmp(value_.data() + pos_tag_start, "</", 2) != 0) continue;
+      size_t pos_tag_start = value_.size - tag_name_.size - 3;
+      if (std::memcmp(value_.data + pos_tag_start, "</", 2) != 0) continue;
 
       // Test for the "tag" bit of "</tag>". Doing case insensitive compare because <I>...</i> is okay.
-      size_t pos_tag_name = value_.size() - tag_name_.size() - 1;  // end - tag>
-      if (!equals_case_insensitive(value_.data() + pos_tag_name, tag_name_.data(), tag_name_.size())) continue;
+      size_t pos_tag_name = value_.size - tag_name_.size - 1;  // end - tag>
+      if (!equals_case_insensitive(value_.data + pos_tag_name, tag_name_.data, tag_name_.size)) continue;
 
       got_tail = true;
-      value_.erase(value_.begin() + pos_tag_start);
+      value_.size -= tag_name_.size + 3;
       break;
     }
   }
-  return TT_DATA;
-}
 
-scanner::token_type scanner::scan_cdata() {
-  if (got_tail) {
-    c_scan = &scanner::scan_body;
-    got_tail = false;
-    return TT_CDATA_END;
-  }
-  value_.clear();
-  while (true) {
-    char c = get_char();
-    if (c == 0) return TT_EOF;
-    value_.push_back(c);
-    if (ends_with(value_, "]]>")) {
-      got_tail = true;
-      value_.erase(value_.end() - 3);
-      break;
-    }
-  }
-  return TT_DATA;
-}
-
-scanner::token_type scanner::scan_pi() {
-  if (got_tail) {
-    c_scan = &scanner::scan_body;
-    got_tail = false;
-    return TT_PI_END;
-  }
-  value_.clear();
-  while (true) {
-    char c = get_char();
-    if (c == 0) return TT_EOF;
-    value_.push_back(c);
-    if (ends_with(value_, "?>")) {
-      got_tail = true;
-      value_.erase(value_.end() - 2);
-      break;
-    }
-  }
-  return TT_DATA;
-}
-
-scanner::token_type scanner::scan_entity_decl() {
-  if (got_tail) {
-    c_scan = &scanner::scan_body;
-    got_tail = false;
-    return TT_ENTITY_END;
-  }
-  value_.clear();
-  char t;
-  unsigned int tc = 0;
-  while (true) {
-    t = get_char();
-    if (t == 0) return TT_EOF;
-    value_.push_back(t);
-    if (t == '\"')
-      tc++;
-    else if (t == '>' && (tc & 1u) == 0) {
-      got_tail = true;
-      break;
-    }
-  }
   return TT_DATA;
 }
 

--- a/src/translator/xh_scanner.cpp
+++ b/src/translator/xh_scanner.cpp
@@ -9,16 +9,12 @@
 
 namespace {
 
+// Simple replacement for str.ends_with(compile-time C string)
 template <typename Char_t, size_t Len>
 inline bool ends_with(std::string const &str, const Char_t (&suffix)[Len]) {
   size_t offset;
   return __builtin_sub_overflow(str.size(), Len - 1, &offset) == 0 &&
          std::memcmp(str.data() + offset, suffix, Len - 1) == 0;
-}
-
-template <typename Char_t, size_t Len>
-inline bool equals(std::string const &str, const Char_t (&str2)[Len]) {
-  return str.size() == Len - 1 && std::memcmp(str.data(), str2, Len - 1) == 0;
 }
 
 inline bool equals_case_insensitive(const char *lhs, const char *rhs, size_t len) {
@@ -31,6 +27,7 @@ inline bool equals_case_insensitive(const char *lhs, const char *rhs, size_t len
   return true;
 }
 
+// Alias for the above, but with compile-time known C string
 template <size_t Len>
 inline bool equals_case_insensitive(std::string const &lhs, const char (&rhs)[Len]) {
   return lhs.size() == Len - 1 && equals_case_insensitive(lhs.data(), rhs, Len);
@@ -199,17 +196,17 @@ scanner::token_type scanner::scan_tag() {
 
     tag_name_.push_back(c);
 
-    if (equals(tag_name_, "!--")) {
+    if (tag_name_ == "!--") {
       c_scan = &scanner::scan_comment;
       return TT_COMMENT_START;
     }
 
-    if (equals(tag_name_, "![CDATA[")) {
+    if (tag_name_ == "![CDATA[") {
       c_scan = &scanner::scan_cdata;
       return TT_CDATA_START;
     }
 
-    if (equals(tag_name_, "!ENTITY")) {
+    if (tag_name_ == "!ENTITY") {
       c_scan = &scanner::scan_entity_decl;
       return TT_ENTITY_START;
     }
@@ -268,27 +265,27 @@ scanner::token_type scanner::scan_entity() {
 }
 
 bool scanner::resolve_entity(std::string const &buffer) {
-  if (equals(buffer, "&lt;")) {
+  if (buffer == "&lt;") {
     value_.push_back('<');
     return true;
   }
-  if (equals(buffer, "&gt;")) {
+  if (buffer == "&gt;") {
     value_.push_back('>');
     return true;
   }
-  if (equals(buffer, "&amp;")) {
+  if (buffer == "&amp;") {
     value_.push_back('&');
     return true;
   }
-  if (equals(buffer, "&quot;")) {
+  if (buffer == "&quot;") {
     value_.push_back('"');
     return true;
   }
-  if (equals(buffer, "&apos;")) {
+  if (buffer == "&apos;") {
     value_.push_back('\'');
     return true;
   }
-  if (equals(buffer, "&nbsp;")) {
+  if (buffer == "&nbsp;") {
     value_.push_back(' ');  // TODO: handle non-breaking spaces better than just converting them to spaces
     return true;
   }

--- a/src/translator/xh_scanner.cpp
+++ b/src/translator/xh_scanner.cpp
@@ -12,9 +12,8 @@ namespace {
 // Simple replacement for str.ends_with(compile-time C string)
 template <typename Char_t, size_t Len>
 inline bool ends_with(markup::string_ref &str, const Char_t (&suffix)[Len]) {
-  size_t offset;
-  return __builtin_sub_overflow(str.size, Len - 1, &offset) == 0 &&
-         std::memcmp(str.data + offset, suffix, Len - 1) == 0;
+  size_t offset = str.size - (Len - 1);
+  return offset <= str.size && std::memcmp(str.data + offset, suffix, Len - 1) == 0;
 }
 
 inline bool equals_case_insensitive(const char *lhs, const char *rhs, size_t len) {

--- a/src/translator/xh_scanner.cpp
+++ b/src/translator/xh_scanner.cpp
@@ -39,11 +39,11 @@ namespace markup {
 
 // case sensitive string equality test
 // s_lowcase shall be lowercase string
-const char *scanner::get_value() { return value_.data(); }
+std::string const &scanner::get_value() const { return value_; }
 
-const char *scanner::get_attr_name() { return attr_name_.data(); }
+std::string const &scanner::get_attr_name() const { return attr_name_; }
 
-const char *scanner::get_tag_name() { return tag_name_.data(); }
+std::string const &scanner::get_tag_name() const { return tag_name_; }
 
 scanner::token_type scanner::scan_body() {
   text_begin = input.p;

--- a/src/translator/xh_scanner.cpp
+++ b/src/translator/xh_scanner.cpp
@@ -3,9 +3,9 @@
 
 #include "xh_scanner.h"
 
+#include <cassert>
 #include <cctype>
 #include <cstring>
-#include <iostream>
 
 namespace {
 

--- a/src/translator/xh_scanner.h
+++ b/src/translator/xh_scanner.h
@@ -5,7 +5,8 @@
 //|
 //| (C) Andrew Fedoniouk @ terrainformatica.com
 //|
-#include <string.h>
+#include <cstring>
+#include <string>
 
 namespace markup {
 struct instream {
@@ -49,8 +50,7 @@ class scanner {
   enum $ { MAX_TOKEN_SIZE = 1024, MAX_NAME_SIZE = 128 };
 
  public:
-  explicit scanner(instream &is)
-      : value_length(0), tag_name_length(0), attr_name_length(0), input(is), input_char(0), got_tail(false) {
+  explicit scanner(instream &is) : tag_name_length(0), attr_name_length(0), input(is), input_char(0), got_tail(false) {
     c_scan = &scanner::scan_body;
   }
 
@@ -104,15 +104,12 @@ class scanner {
 
   static bool is_whitespace(char c);
 
-  void append_value(char c);
-
   void append_attr_name(char c);
 
   void append_tag_name(char c);
 
  private: /* data */
-  char value[MAX_TOKEN_SIZE]{};
-  unsigned int value_length;
+  std::string value_;
 
   char tag_name[MAX_NAME_SIZE]{};
   unsigned int tag_name_length;

--- a/src/translator/xh_scanner.h
+++ b/src/translator/xh_scanner.h
@@ -47,12 +47,10 @@ class scanner {
 
   };
 
-  enum $ { MAX_TOKEN_SIZE = 1024, MAX_NAME_SIZE = 128 };
+  enum $ { MAX_ENTITY_SIZE = 8 };
 
  public:
-  explicit scanner(instream &is) : tag_name_length(0), attr_name_length(0), input(is), input_char(0), got_tail(false) {
-    c_scan = &scanner::scan_body;
-  }
+  explicit scanner(instream &is) : input(is), input_char(0), got_tail(false) { c_scan = &scanner::scan_body; }
 
   // get next token
   token_type get_token() { return (this->*c_scan)(); }
@@ -100,7 +98,7 @@ class scanner {
 
   char get_char();
 
-  bool resolve_entity(char *buffer, unsigned int len);
+  bool resolve_entity(std::string const &bufer);
 
   static bool is_whitespace(char c);
 
@@ -110,12 +108,8 @@ class scanner {
 
  private: /* data */
   std::string value_;
-
-  char tag_name[MAX_NAME_SIZE]{};
-  unsigned int tag_name_length;
-
-  char attr_name[MAX_NAME_SIZE]{};
-  unsigned int attr_name_length;
+  std::string tag_name_;
+  std::string attr_name_;
 
   instream &input;
   char input_char;

--- a/src/translator/xh_scanner.h
+++ b/src/translator/xh_scanner.h
@@ -56,17 +56,17 @@ class scanner {
   token_type get_token() { return (this->*c_scan)(); }
 
   // get text span backed by original input.
-  const char *get_text_begin() { return text_begin; }
-  const char *get_text_end() { return text_end; }
+  const char *get_text_begin() const { return text_begin; }
+  const char *get_text_end() const { return text_end; }
 
   // get value of TT_TEXT, TT_ATTR and TT_DATA
-  const char *get_value();
+  std::string const &get_value() const;
 
   // get attribute name
-  const char *get_attr_name();
+  std::string const &get_attr_name() const;
 
   // get tag name (always lowercase)
-  const char *get_tag_name();
+  std::string const &get_tag_name() const;
 
  private: /* methods */
   typedef token_type (scanner::*scan)();

--- a/src/translator/xh_scanner.h
+++ b/src/translator/xh_scanner.h
@@ -7,8 +7,7 @@
 //|
 #include <cassert>
 #include <cstring>
-#include <ostream>
-#include <string>
+#include <string_view>
 
 namespace markup {
 
@@ -23,22 +22,11 @@ struct instream {
   const char *pos() const { return p; }
 };
 
-// Very simple string_view implementation that has mutable size so we can easily
-// grow or shrink it while we scan through the input.
-struct string_view {
+// Think string_view, but with a mutable range
+struct string_ref {
   const char *data;
   size_t size;
-  char back() const {
-    assert(size > 0);
-    return data[size - 1];
-  }
-  std::string str() const { return std::string(data, size); };
-
-  // operator std::string() const { return str(); }  // Note: not exposing the std::string cast make
-  // (accidental) string allocations explicit
 };
-
-inline std::ostream &operator<<(std::ostream &out, string_view str) { return out.write(str.data, str.size); }
 
 class scanner {
  public:
@@ -70,13 +58,13 @@ class scanner {
   token_type next_token() { return (this->*c_scan)(); }
 
   // get value of TT_TEXT, TT_ATTR and TT_DATA
-  string_view value() const;
+  std::string_view value() const;
 
   // get attribute name
-  string_view attr_name() const;
+  std::string_view attr_name() const;
 
   // get tag name
-  string_view tag_name() const;
+  std::string_view tag_name() const;
 
  private: /* methods */
   typedef token_type (scanner::*scan)();
@@ -103,14 +91,14 @@ class scanner {
 
   size_t skip_whitespace();
 
-  bool resolve_entity(string_view const &buffer, string_view &decoded) const;
+  bool resolve_entity(string_ref const &buffer, string_ref &decoded) const;
 
   static bool is_whitespace(char c);
 
  private: /* data */
-  string_view value_;
-  string_view tag_name_;
-  string_view attr_name_;
+  string_ref value_;
+  string_ref tag_name_;
+  string_ref attr_name_;
 
   instream &input_;
 

--- a/src/translator/xh_scanner.h
+++ b/src/translator/xh_scanner.h
@@ -5,17 +5,40 @@
 //|
 //| (C) Andrew Fedoniouk @ terrainformatica.com
 //|
+#include <cassert>
 #include <cstring>
+#include <ostream>
 #include <string>
 
 namespace markup {
+
 struct instream {
   const char *p;
+  const char *begin;
   const char *end;
-  explicit instream(const char *src) : p(src), end(src + strlen(src)) {}
-  instream(const char *begin, const char *end) : p(begin), end(end) {}
-  char get_char() { return p < end ? *p++ : 0; }
+  explicit instream(const char *src) : p(src), begin(src), end(src + strlen(src)) {}
+  instream(const char *begin, const char *end) : p(begin), begin(begin), end(end) {}
+  char consume() { return p < end ? *p++ : 0; }
+  char peek() const { return p < end ? *p : 0; }
+  const char *pos() const { return p; }
 };
+
+// Very simple string_view implementation that has mutable size so we can easily
+// grow or shrink it while we scan through the input.
+struct string_view {
+  const char *data;
+  size_t size;
+  char back() const {
+    assert(size > 0);
+    return data[size - 1];
+  }
+  std::string str() const { return std::string(data, size); };
+
+  // operator std::string() const { return str(); }  // Note: not exposing the std::string cast make
+  // (accidental) string allocations explicit
+};
+
+inline std::ostream &operator<<(std::ostream &out, string_view str) { return out.write(str.data, str.size); }
 
 class scanner {
  public:
@@ -38,80 +61,59 @@ class scanner {
 
     TT_COMMENT_START,
     TT_COMMENT_END,  // after "<!--" and "-->"
-    TT_CDATA_START,
-    TT_CDATA_END,  // after "<![CDATA[" and "]]>"
-    TT_PI_START,
-    TT_PI_END,  // after "<?" and "?>"
-    TT_ENTITY_START,
-    TT_ENTITY_END,  // after "<!ENTITY" and ">"
-
   };
 
-  enum $ { MAX_ENTITY_SIZE = 8 };
-
  public:
-  explicit scanner(instream &is) : input(is), input_char(0), got_tail(false) { c_scan = &scanner::scan_body; }
+  explicit scanner(instream &is) : input_(is), got_tail(false) { c_scan = &scanner::scan_body; }
 
   // get next token
-  token_type get_token() { return (this->*c_scan)(); }
-
-  // get text span backed by original input.
-  const char *get_text_begin() const { return text_begin; }
-  const char *get_text_end() const { return text_end; }
+  token_type next_token() { return (this->*c_scan)(); }
 
   // get value of TT_TEXT, TT_ATTR and TT_DATA
-  std::string const &get_value() const;
+  string_view value() const;
 
   // get attribute name
-  std::string const &get_attr_name() const;
+  string_view attr_name() const;
 
-  // get tag name (always lowercase)
-  std::string const &get_tag_name() const;
+  // get tag name
+  string_view tag_name() const;
 
  private: /* methods */
   typedef token_type (scanner::*scan)();
 
   scan c_scan;  // current 'reader'
 
-  // content 'readers'
+  // Consumes the text around and between tags
   token_type scan_body();
 
-  token_type scan_head();
+  // Consumes name="attr"
+  token_type scan_attr();
 
+  // Consumes <!-- ... -->
   token_type scan_comment();
 
-  token_type scan_cdata();
-
+  // Consumes ...</style> and ...</script>
   token_type scan_special();
 
-  token_type scan_pi();
-
+  // Consumes <tagname and </tagname>
   token_type scan_tag();
 
-  token_type scan_entity();
+  // Consumes '&amp;' etc, emits parent_token_type
+  token_type scan_entity(token_type parent_token_type);
 
-  token_type scan_entity_decl();
+  size_t skip_whitespace();
 
-  char skip_whitespace();
-
-  void push_back(char c);
-
-  char get_char();
-
-  bool resolve_entity(std::string const &bufer);
+  bool resolve_entity(string_view const &buffer, string_view &decoded) const;
 
   static bool is_whitespace(char c);
 
  private: /* data */
-  std::string value_;
-  std::string tag_name_;
-  std::string attr_name_;
+  string_view value_;
+  string_view tag_name_;
+  string_view attr_name_;
 
-  instream &input;
-  char input_char;
+  instream &input_;
 
-  bool got_tail;  // aux flag used in scan_comment, etc.
-
-  const char *text_begin, *text_end;
+  bool got_tail;  // aux flag used in scan_comment
 };
 }  // namespace markup

--- a/src/translator/xh_scanner.h
+++ b/src/translator/xh_scanner.h
@@ -102,10 +102,6 @@ class scanner {
 
   static bool is_whitespace(char c);
 
-  void append_attr_name(char c);
-
-  void append_tag_name(char c);
-
  private: /* data */
   std::string value_;
   std::string tag_name_;


### PR DESCRIPTION
The HTML parser used internal stack-allocated buffers for text, tags, and attributes. This change replaces them with std::string_view.

This is a fix for #273.

Related issue in warc2text: https://github.com/bitextor/warc2text/issues/32, but less impact because that doesn't use these buffers for text between tags as it does entity decoding at another place.

This change also removes the fallback tag alignment code. Now if there is no alignment information available, no HTML tags will be inserted into the output. This would have already been enforced by #271 by always requesting alignment info from the model if ResponseOptions.HTML was true, so there should be no impact outside of the HTML class and tests. (And if there is the integration tests will call me on it.)

Edit: furthermore, this pulled in some tiny improvements:
- Jerin requested earlier that the lifetime of `new Tag` was a bit better explained
- I noticed that end tokens of sentences were not always aligned with each other if you just go by score. That's now enforced.
- Bit more consistency in using `numSentences()` and `numWords()` instead of suddenly jumping over to `alignments[..].size()`.