### PR TITLE
Increase HTML test coverage

### DIFF
--- a/src/tests/units/xh_scanner_tests.cpp
+++ b/src/tests/units/xh_scanner_tests.cpp
@@ -57,6 +57,28 @@ TEST_CASE("scan element with unquoted attributes") {
   CHECK(scanner.next_token() == markup::scanner::TT_EOF);
 }
 
+TEST_CASE("scan element with spaces around attributes") {
+  markup::instream in("<input class = \"test\" checked type = checkbox >");
+  markup::scanner scanner(in);
+
+  CHECK(scanner.next_token() == markup::scanner::TT_TAG_START);
+  CHECK(scanner.tag_name() == "input");
+
+  CHECK(scanner.next_token() == markup::scanner::TT_ATTR);
+  CHECK(scanner.attr_name() == "class");
+  CHECK(scanner.value() == "test");
+
+  CHECK(scanner.next_token() == markup::scanner::TT_ATTR);
+  CHECK(scanner.attr_name() == "checked");
+  CHECK(scanner.value() == "");
+
+  CHECK(scanner.next_token() == markup::scanner::TT_ATTR);
+  CHECK(scanner.attr_name() == "type");
+  CHECK(scanner.value() == "checkbox");
+
+  CHECK(scanner.next_token() == markup::scanner::TT_EOF);
+}
+
 TEST_CASE("scan element with text") {
   markup::instream in("<span>Hello world</span>");
   markup::scanner scanner(in);

--- a/src/translator/html.cpp
+++ b/src/translator/html.cpp
@@ -174,10 +174,17 @@ bool HasAlignments(Response const &response) {
   // Test for each sentence individually as a sentence may be empty (or there)
   // might be no sentences, so just testing for alignments.empty() would not be
   // sufficient.
-  for (size_t sentenceIdx = 0; sentenceIdx < response.target.numSentences(); ++sentenceIdx)
+  for (size_t sentenceIdx = 0; sentenceIdx < response.target.numSentences(); ++sentenceIdx) {
+    // If response.alignments is just empty, this might catch it.
     if (response.alignments.size() <= sentenceIdx ||
         response.alignments[sentenceIdx].size() != response.target.numWords(sentenceIdx))
       return false;
+
+    // If response.alignments is "empty" because the model did not provide alignments,
+    // it still has entries for each target word. But all these entries are empty.
+    for (size_t wordIdx = 0; wordIdx < response.target.numWords(sentenceIdx); ++wordIdx)
+      if (response.alignments[sentenceIdx][wordIdx].size() != response.source.numWords(sentenceIdx)) return false;
+  }
   return true;
 }
 

--- a/src/translator/xh_scanner.cpp
+++ b/src/translator/xh_scanner.cpp
@@ -29,7 +29,7 @@ inline bool equals_case_insensitive(const char *lhs, const char *rhs, size_t len
 // Alias for the above, but with compile-time known C string
 template <size_t Len>
 inline bool equals_case_insensitive(markup::string_ref &lhs, const char (&rhs)[Len]) {
-  return lhs.size == Len - 1 && equals_case_insensitive(lhs.data, rhs, Len);
+  return lhs.size == Len - 1 && equals_case_insensitive(lhs.data, rhs, Len - 1);
 }
 
 template <typename Char_t, size_t Len>

--- a/src/translator/xh_scanner.cpp
+++ b/src/translator/xh_scanner.cpp
@@ -131,11 +131,16 @@ scanner::token_type scanner::scan_attr() {
       case '\0':
         return TT_EOF;
       case '>':
-        return TT_ATTR;  // attribute without value (HTML style)
+        return TT_ATTR;  // attribute without value (HTML style) at end of tag
       case '<':
         return TT_ERROR;
       default:
-        if (skip_whitespace()) continue;
+        if (skip_whitespace()) {
+          if (input_.peek() == '=')
+            break;
+          else
+            return TT_ATTR;  // attribute without value (HTML style) but not yet at end of tag
+        }
         input_.consume();
         ++attr_name_.size;
         break;

--- a/src/translator/xh_scanner.h
+++ b/src/translator/xh_scanner.h
@@ -52,7 +52,10 @@ class scanner {
   };
 
  public:
-  explicit scanner(instream &is) : input_(is), got_tail(false) { c_scan = &scanner::scan_body; }
+  explicit scanner(instream &is)
+      : value_{nullptr, 0}, tag_name_{nullptr, 0}, attr_name_{nullptr, 0}, input_(is), got_tail(false) {
+    c_scan = &scanner::scan_body;
+  }
 
   // get next token
   token_type next_token() { return (this->*c_scan)(); }


### PR DESCRIPTION
This pull request covers adding unit tests until I'm close to 100% test coverage of the xh_scanner and HTML code. And fix any issues I identify while doing that.

Issues found and fixed:
- Accessing `scanner.value()`, `attr_name()` or `tag_name()` before a relevant token had been identified would point to random memory, which could lead to segfaults.
- Parsing `<script>` and `<style>` tags. These were treated as normal elements, but HTML spec allows use of unescaped entities inside them. It's a bit pointless to send these to the translation service anyway.
- Parsing around unquoted and valueless attributes, specifically when mixed. I don't think `Element.innerHTML` would ever give you any of these, but if external HTML is ever allowed (I see a web service being created…) support might come in handy. xh_scanner already had some support for it anyway.