### PR TITLE
Adding circle ci job to push the wasm artifacts to github releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
               cp bergamot-translator-worker.wasm ../artifacts/bergamot-translator-worker-with-wormhole.wasm
               cp bergamot-translator-worker.js ../artifacts/bergamot-translator-worker-with-wormhole.js
               shasum -a 256 ../artifacts/* > ../artifacts/SHA256-1
-              cp BERGAMOT_VERSION ../artifacts/
+              cp ../BERGAMOT_VERSION ../artifacts/
             else
               echo "Failure: Artifacts Not Present"
               exit 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,11 +23,11 @@ jobs:
             if ls bergamot*.wasm &>/dev/null && ls bergamot*.js &>/dev/null
             then
               echo "Artifacts Successfully Generated"
-              mkdir artifacts
-              cp build-wasm/bergamot-translator-worker.wasm artifacts/bergamot-translator-worker-with-wormhole.wasm
-              cp build-wasm/bergamot-translator-worker.js artifacts/bergamot-translator-worker-with-wormhole.js
-              shasum -a 256 ./artifacts/* > ./artifacts/SHA256-1
-              cp BERGAMOT_VERSION ./artifacts/
+              mkdir ../artifacts
+              cp bergamot-translator-worker.wasm ../artifacts/bergamot-translator-worker-with-wormhole.wasm
+              cp bergamot-translator-worker.js ../artifacts/bergamot-translator-worker-with-wormhole.js
+              shasum -a 256 ../artifacts/* > ../artifacts/SHA256-1
+              cp BERGAMOT_VERSION ../artifacts/
             else
               echo "Failure: Artifacts Not Present"
               exit 1
@@ -65,10 +65,10 @@ jobs:
             if ls bergamot*.wasm &>/dev/null && ls bergamot*.js &>/dev/null
             then
               echo "Artifacts Successfully Generated"
-              mkdir artifacts
-              cp build-wasm/bergamot-translator-worker.wasm artifacts/bergamot-translator-worker-without-wormhole.wasm
-              cp build-wasm/bergamot-translator-worker.js artifacts/bergamot-translator-worker-without-wormhole.js
-              shasum -a 256 ./artifacts/* > ./artifacts/SHA256-2
+              mkdir ../artifacts
+              cp bergamot-translator-worker.wasm ../artifacts/bergamot-translator-worker-without-wormhole.wasm
+              cp bergamot-translator-worker.js ../artifacts/bergamot-translator-worker-without-wormhole.js
+              shasum -a 256 ../artifacts/* > ../artifacts/SHA256-2
             else
               echo "Failure: Artifacts Not Present"
               exit 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
           name: "Publish Release on GitHub"
           command: |
             export COMMIT=$(echo $CIRCLE_SHA1 | cut -c -7)
-            export VERSION=$(cat ./artifacts/BERGAMOT_VERSION)
+            export VERSION=$(cat ./artifacts/BERGAMOT_VERSION | cut -c 2-)
             VERSION=$VERSION+$COMMIT
             ls -lsa ./artifacts/ > ./artifacts/FILESIZES
             cat ./artifacts/SHA256-1 ./artifacts/SHA256-2 > ./artifacts/SHA256

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,6 @@ jobs:
        - run:
           name: "Publish Release on GitHub"
           command: |
-
             export COMMIT=$(echo $CIRCLE_SHA1 | cut -c -7)
             export VERSION=$(cat ./artifacts/BERGAMOT_VERSION)
             VERSION=$VERSION+$COMMIT
@@ -100,7 +99,6 @@ jobs:
             rm ./artifacts/SHA256-1
             rm ./artifacts/SHA256-2
             rm ./artifacts/BERGAMOT_VERSION
-
             ghr -t ${GHTOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} ./artifacts/
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,9 @@ jobs:
       - checkout
 
       - run:
-          name: Build WASM
-          command: bash build-wasm.sh WORMHOLE
+          name: Build WASM WORMHOLE
+          command: |
+            bash build-wasm.sh WORMHOLE
 
       - run:
           name: Check artifacts
@@ -22,10 +23,20 @@ jobs:
             if ls bergamot*.wasm &>/dev/null && ls bergamot*.js &>/dev/null
             then
               echo "Artifacts Successfully Generated"
+              mkdir artifacts
+              cp build-wasm/bergamot-translator-worker.wasm artifacts/bergamot-translator-worker-with-wormhole.wasm
+              cp build-wasm/bergamot-translator-worker.js artifacts/bergamot-translator-worker-with-wormhole.js
+              shasum -a 256 ./artifacts/* > ./artifacts/SHA256-1
+              cp BERGAMOT_VERSION ./artifacts/
             else
               echo "Failure: Artifacts Not Present"
               exit 1
             fi
+
+      - persist_to_workspace:
+          root: .
+          paths:
+            - artifacts/*
 
       - store_artifacts:
           path: "build-wasm"
@@ -43,7 +54,8 @@ jobs:
 
       - run:
           name: Build WASM
-          command: bash build-wasm.sh
+          command: |
+            bash build-wasm.sh
 
       - run:
           name: Check artifacts
@@ -53,17 +65,63 @@ jobs:
             if ls bergamot*.wasm &>/dev/null && ls bergamot*.js &>/dev/null
             then
               echo "Artifacts Successfully Generated"
+              mkdir artifacts
+              cp build-wasm/bergamot-translator-worker.wasm artifacts/bergamot-translator-worker-without-wormhole.wasm
+              cp build-wasm/bergamot-translator-worker.js artifacts/bergamot-translator-worker-without-wormhole.js
+              shasum -a 256 ./artifacts/* > ./artifacts/SHA256-2
             else
               echo "Failure: Artifacts Not Present"
               exit 1
             fi
+      - persist_to_workspace:
+          root: .
+          paths:
+            - artifacts/*
 
       - store_artifacts:
           path: "build-wasm"
           destination: "wasm-without-wormhole"
+  publish_to_github:
+     docker:
+       - image: cibuilds/github:0.10
+     steps:
+       - attach_workspace:
+          # Must be absolute path or relative path from working_directory
+          at: ./
+       - run:
+          name: "Publish Release on GitHub"
+          command: |
+
+            export COMMIT=$(echo $CIRCLE_SHA1 | cut -c -7)
+            export VERSION=$(cat ./artifacts/BERGAMOT_VERSION)
+            VERSION=$VERSION+$COMMIT
+            ls -lsa ./artifacts/ > ./artifacts/FILESIZES
+            cat ./artifacts/SHA256-1 ./artifacts/SHA256-2 > ./artifacts/SHA256
+            rm ./artifacts/SHA256-1
+            rm ./artifacts/SHA256-2
+            rm ./artifacts/BERGAMOT_VERSION
+
+            ghr -t ${GHTOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} ./artifacts/
 
 workflows:
   build:
       jobs:
-          - build-with-wormhole
-          - build-without-wormhole
+          - build-with-wormhole:
+              filters:
+                tags:
+                  only: /^v.*/
+          - build-without-wormhole:
+              filters:
+                tags:
+                  only: /^v.*/
+          - publish_to_github:
+              filters:
+                tags:
+                  only: /^v.*/
+                branches:
+                  ignore: /.*/
+              requires:
+                - build-without-wormhole
+                - build-with-wormhole
+
+


### PR DESCRIPTION
We need a way to auto publish builds to github releases to facilitate the integration with the extension, so this patch introduces that to circle ci whenever a tag is created. This job can remain disabled here, since we intend to use it only on [github.com/mozilla/bergamot-translator](https://github.com/mozilla/bergamot-translator).

Artifacts and releases will be created like this: https://github.com/andrenatal/bergamot-translator/releases