### PR TITLE
GitHub CI: Update YAML to run all tests on marian-full

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -25,19 +25,19 @@ jobs:
           os: ubuntu-18.04
           identifier: ubuntu_1804_full
           cmake: -DCOMPILE_TESTS=on
-          brt_tags: "'#native'"
+          brt_args: ""
           unittests: 'true'
         - name: Ubuntu 18.04 minimal
           os: ubuntu-18.04
           identifier: ubuntu_1804_minimal
           cmake: -DCOMPILE_TESTS=on -DUSE_WASM_COMPATIBLE_SOURCE=on
-          brt_tags: "'#wasm'"
+          brt_args: "'#wasm'"
           unittests: 'false'
         - name: Ubuntu 20.04 full
           os: ubuntu-20.04
           identifier: ubuntu_2004_full
           cmake: -DCOMPILE_TESTS=on
-          brt_tags: "'#native'"
+          brt_tags: ""
           unittests: 'true'
         - name: Ubuntu 20.04 minimal
           os: ubuntu-20.04
@@ -140,7 +140,7 @@ jobs:
           os: macos-10.15
           identifier: mac_1015_full
           cmake: -DCOMPILE_TESTS=on -DUSE_APPLE_ACCELERATE=off -DUSE_FBGEMM=off -DUSE_STATIC_LIBS=off
-          brt_tags: "'#native'"
+          brt_tags: ""
           unittests: 'true'
         - name: MacOS 10.15 minimal
           os: macos-10.15


### PR DESCRIPTION
This is a change that was missed in #252 that updates GitHub CI yaml files to run whole tests using the new separation (wasm, blocking, async, cli). 

Will be merged at own-risk after inspecting GitHub CI runs.