### PR TITLE
Fix typo in BRT args on CI runs

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -25,13 +25,13 @@ jobs:
           os: ubuntu-18.04
           identifier: ubuntu_1804_full
           cmake: -DCOMPILE_TESTS=on
-          brt_args: ""
+          brt_tags: ""
           unittests: 'true'
         - name: Ubuntu 18.04 minimal
           os: ubuntu-18.04
           identifier: ubuntu_1804_minimal
           cmake: -DCOMPILE_TESTS=on -DUSE_WASM_COMPATIBLE_SOURCE=on
-          brt_args: "'#wasm'"
+          brt_tags: "'#wasm'"
           unittests: 'false'
         - name: Ubuntu 20.04 full
           os: ubuntu-20.04


### PR DESCRIPTION
Merging at own risk. Somehow the buggy workflow file passed a few CI runs until runners swapped hardware. :-| 