### PR TITLE
Turn logging off by default, allow turning on via config/cmdline

### DIFF
--- a/src/translator/logging.h
+++ b/src/translator/logging.h
@@ -16,7 +16,7 @@ class Logger {
     }
   };
 
-  Logger(const Config &config) : config_(config), marianLoggers_(createLoggers()) {
+  Logger(const Config &config) : marianLoggers_(createLoggers()) {
     // We are manually creating loggers, because this is usually created in marian as a side-effect of
     // config-parsing.
     for (auto &logger : marianLoggers_) {
@@ -24,6 +24,8 @@ class Logger {
     }
   }
 
+  // Taken from
+  // https://github.com/marian-nmt/marian-dev/blob/c84599d08ad69059279abd5a7417a8053db8b631/src/common/logging.cpp#L45
   static bool setLoggingLevel(spdlog::logger &logger, std::string const level) {
     if (level == "trace")
       logger.set_level(spdlog::level::trace);
@@ -64,7 +66,6 @@ class Logger {
  private:
   using MarianLogger = std::shared_ptr<spdlog::logger>;
   std::vector<MarianLogger> marianLoggers_;
-  Config config_;
 };
 }  // namespace bergamot
 }  // namespace marian

--- a/src/translator/service.cpp
+++ b/src/translator/service.cpp
@@ -11,7 +11,11 @@ namespace marian {
 namespace bergamot {
 
 BlockingService::BlockingService(const BlockingService::Config &config)
-    : config_(config), requestId_(0), batchingPool_(), cache_(config.cacheSize, /*mutexBuckets=*/1) {}
+    : config_(config),
+      requestId_(0),
+      batchingPool_(),
+      cache_(config.cacheSize, /*mutexBuckets=*/1),
+      logger_(config.logger) {}
 
 std::vector<Response> BlockingService::translateMultiple(std::shared_ptr<TranslationModel> translationModel,
                                                          std::vector<std::string> &&sources,
@@ -37,7 +41,11 @@ std::vector<Response> BlockingService::translateMultiple(std::shared_ptr<Transla
 }
 
 AsyncService::AsyncService(const AsyncService::Config &config)
-    : requestId_(0), config_(config), safeBatchingPool_(), cache_(config_.cacheSize, config_.cacheMutexBuckets) {
+    : requestId_(0),
+      config_(config),
+      safeBatchingPool_(),
+      cache_(config_.cacheSize, config_.cacheMutexBuckets),
+      logger_(config.logger) {
   ABORT_IF(config_.numWorkers == 0, "Number of workers should be at least 1 in a threaded workflow");
   workers_.reserve(config_.numWorkers);
   for (size_t cpuId = 0; cpuId < config_.numWorkers; cpuId++) {

--- a/src/translator/service.h
+++ b/src/translator/service.h
@@ -33,11 +33,14 @@ class BlockingService {
     bool cacheEnabled{false};  ///< Whether to enable cache or not.
     size_t cacheSize{2000};    ///< Size in History items to be stored in the cache. Loosely corresponds to sentences to
                                /// cache in the real world.
+    Logger::Config logger;     // Configurations for logging
+
     template <class App>
     static void addOptions(App &app, Config &config) {
       // Options will come here.
       app.add_option("--cache-translations", config.cacheEnabled, "Whether to cache translations or not.");
       app.add_option("--cache-size", config.cacheSize, "Number of entries to store in cache.");
+      Logger::Config::addOptions(app, config.logger);
     }
   };
   /// Construct a BlockingService with configuration loaded from an Options object. Does not require any keys, values to
@@ -90,6 +93,8 @@ class AsyncService {
     size_t cacheMutexBuckets{1};  ///< Controls the granularity of locking to reduce contention by bucketing mutexes
                                   ///< guarding cache entry read write. Optimal at min(core, numWorkers) assuming a
                                   ///< reasonably large cache-size.
+    Logger::Config logger;        // Configurations for logging
+
     template <class App>
     static void addOptions(App &app, Config &config) {
       app.add_option("--cpu-threads", config.numWorkers, "Workers to form translation backend");
@@ -97,6 +102,7 @@ class AsyncService {
       app.add_option("--cache-size", config.cacheSize, "Number of entries to store in cache.");
       app.add_option("--cache-mutex-buckets", config.cacheMutexBuckets,
                      "Number of mutex buckets to control locking granularity");
+      Logger::Config::addOptions(app, config.logger);
     }
   };
   /// Construct an AsyncService with configuration loaded from Options. Expects positive integer value for


### PR DESCRIPTION
[WIP] Preliminary piecing together of logging control functions from marian to allow some form of control on logging. 

My immediate use-case is to avoid all the dump coming which I don't need at:

```
(env) [jerin@eltbk lemonade]$ echo "Hello World" | bergamot translate -m en-de-tiny
[2021-12-31 11:35:19] [data] Loading SentencePiece vocabulary from file /home/jerin/.local/share/lemonade/models/ende.student.tiny11/vocab.deen.spm
[2021-12-31 11:35:19] Missing list of protected prefixes for sentence splitting. Set with --ssplit-prefix-file.
[2021-12-31 11:35:19] [data] Loading binary shortlist as /home/jerin/.local/share/lemonade/models/ende.student.tiny11/lex.s2t.bin false
[2021-12-31 11:35:19] [data] Lexical short list firstNum 50 and bestNum 50
[2021-12-31 11:35:19] [memory] Extending reserved space to 128 MB (device cpu0)
[2021-12-31 11:35:19] Loaded model config
[2021-12-31 11:35:19] Loading scorer of type transformer as feature F0
[2021-12-31 11:35:19] [memory] Reserving 31 MB, device cpu0
[2021-12-31 11:35:19] [memory] Reserving 8 MB, device cpu0
[2021-12-31 11:35:19] [memory] Extending reserved space to 128 MB (device cpu1)
[2021-12-31 11:35:19] Loaded model config
[2021-12-31 11:35:19] Loading scorer of type transformer as feature F0
[2021-12-31 11:35:19] [memory] Reserving 31 MB, device cpu1
[2021-12-31 11:35:19] [memory] Reserving 8 MB, device cpu1
[2021-12-31 11:35:19] [memory] Extending reserved space to 128 MB (device cpu2)
[2021-12-31 11:35:19] Loaded model config
[2021-12-31 11:35:20] Loading scorer of type transformer as feature F0
[2021-12-31 11:35:20] [memory] Reserving 31 MB, device cpu2
[2021-12-31 11:35:20] [memory] Reserving 8 MB, device cpu2
[2021-12-31 11:35:20] [memory] Extending reserved space to 128 MB (device cpu3)
[2021-12-31 11:35:20] Loaded model config
[2021-12-31 11:35:20] Loading scorer of type transformer as feature F0
[2021-12-31 11:35:20] [memory] Reserving 31 MB, device cpu3
[2021-12-31 11:35:20] [memory] Reserving 8 MB, device cpu3
Hello Welt
```

I'm guessing this is useful for translateLocally (cmdline at least) as well? @XapaJIaMnu @jelmervdl - thoughts?