### PR TITLE
Have alignments placed if HTML is on

### DIFF
--- a/src/translator/response_builder.h
+++ b/src/translator/response_builder.h
@@ -61,7 +61,7 @@ class ResponseBuilder {
       buildQualityScores(histories, response);
     }
 
-    if (responseOptions_.alignment) {
+    if (responseOptions_.alignment or responseOptions_.HTML) {
       buildAlignments(histories, response);
     }
     html_.restore(response);

--- a/src/translator/response_builder.h
+++ b/src/translator/response_builder.h
@@ -61,7 +61,7 @@ class ResponseBuilder {
       buildQualityScores(histories, response);
     }
 
-    if (responseOptions_.alignment or responseOptions_.HTML) {
+    if (responseOptions_.alignment || responseOptions_.HTML) {
       buildAlignments(histories, response);
     }
     html_.restore(response);


### PR DESCRIPTION
Fixes one half of #270. 

https://github.com/browsermt/bergamot-translator/pull/271 tries to provide a `sanitizeOptions`, which is perhaps more extensible. But such a function will have to be called at several sites increasing verbosity is my conclusion after experimenting in https://github.com/jerinphilip/bergamot-translator/pull/28.

Instead, we just pick-up `ResponseOptions.HTML` and place alignments with an `or` switch if `HTML` is on, irrespective of whatever value was given for `Alignment`s.

This way a client can go from:

```
$ cat | bergamot translate -m en-es-tiny --html=1 --alignment=1 
<a href="Tintin">Tintin</a>'s dog is a good dog.
El perro de <a href="Tintin">Tintín</a> es un buen perro.
```

to

```
$ cat | bergamot translate -m en-es-tiny --html=1 
<a href="Tintin">Tintin</a>'s dog is a good dog.
El perro de <a href="Tintin">Tintín</a> es un buen perro.
```

(This is tested with python-cmdline).

Should work similarly with `ResponseOptions` for WebAssembly as well.