### PR TITLE
Streamline memory-bundle loads

### DIFF
--- a/app/bergamot.cpp
+++ b/app/bergamot.cpp
@@ -16,8 +16,7 @@ int main(int argc, char *argv[]) {
   // Construct a model.
   auto options = parseOptionsFromFilePath(config.modelConfigPaths.front());
 
-  MemoryBundle memoryBundle;
-  std::shared_ptr<TranslationModel> model = service.createCompatibleModel(options, std::move(memoryBundle));
+  std::shared_ptr<TranslationModel> model = service.createCompatibleModel(options);
 
   ResponseOptions responseOptions;
   std::string input = readFromStdin();

--- a/examples/run-native.sh
+++ b/examples/run-native.sh
@@ -14,6 +14,6 @@ python3 bergamot-translator-tests/tools/patch-marian-for-bergamot.py \
 # Patched config file will be available with .bergamot.yml suffix.
 CONFIG=models/ende.student.tiny11/config.intgemm8bitalpha.yml.bergamot.yml
 
-build/app/bergamot --model-config-paths $CONFIG --cpu-threads 4 <<< "Hello World!"
+build/app/bergamot --model-config-paths $CONFIG --cpu-threads 4 --log-level info <<< "Hello World!"
 # Hallo Welt!
 

--- a/examples/run-native.sh
+++ b/examples/run-native.sh
@@ -9,7 +9,7 @@ wget --quiet --continue --directory models/ \
 # Patch the config-files generated from marian for use in bergamot.
 python3 bergamot-translator-tests/tools/patch-marian-for-bergamot.py \
     --config-path models/ende.student.tiny11/config.intgemm8bitalpha.yml \
-    --ssplit-prefix-file $(realpath 3rd-party/ssplit-cpp/split-cpp/nonbreaking_prefixes/nonbreaking_prefix.en)
+    --ssplit-prefix-file $(realpath 3rd_party/ssplit-cpp/nonbreaking_prefixes/nonbreaking_prefix.en)
 
 # Patched config file will be available with .bergamot.yml suffix.
 CONFIG=models/ende.student.tiny11/config.intgemm8bitalpha.yml.bergamot.yml

--- a/examples/run-native.sh
+++ b/examples/run-native.sh
@@ -9,7 +9,7 @@ wget --quiet --continue --directory models/ \
 # Patch the config-files generated from marian for use in bergamot.
 python3 bergamot-translator-tests/tools/patch-marian-for-bergamot.py \
     --config-path models/ende.student.tiny11/config.intgemm8bitalpha.yml \
-    --ssplit-prefix-file 3rd-party/ssplit-cpp/split-cpp/nonbreaking_prefixes/nonbreaking_prefix.en
+    --ssplit-prefix-file $(realpath 3rd-party/ssplit-cpp/split-cpp/nonbreaking_prefixes/nonbreaking_prefix.en)
 
 # Patched config file will be available with .bergamot.yml suffix.
 CONFIG=models/ende.student.tiny11/config.intgemm8bitalpha.yml.bergamot.yml

--- a/examples/run-native.sh
+++ b/examples/run-native.sh
@@ -14,6 +14,6 @@ python3 bergamot-translator-tests/tools/patch-marian-for-bergamot.py \
 # Patched config file will be available with .bergamot.yml suffix.
 CONFIG=models/ende.student.tiny11/config.intgemm8bitalpha.yml.bergamot.yml
 
-build/app/bergamot --model-config-paths $CONFIG --cpu-threads 4 --log-level info <<< "Hello World!"
+build/app/bergamot --model-config-paths $CONFIG --cpu-threads 4 <<< "Hello World!"
 # Hallo Welt!
 

--- a/src/translator/byte_array_util.cpp
+++ b/src/translator/byte_array_util.cpp
@@ -101,10 +101,12 @@ AlignedMemory getModelMemoryFromConfig(marian::Ptr<marian::Options> options) {
 
 AlignedMemory getShortlistMemoryFromConfig(marian::Ptr<marian::Options> options) {
   auto shortlist = options->get<std::vector<std::string>>("shortlist");
-  ABORT_IF(shortlist.empty(), "No path to shortlist file is given.");
-  ABORT_IF(!marian::data::isBinaryShortlist(shortlist[0]),
-           "Loading non-binary shortlist file into memory is not supported");
-  return loadFileToMemory(shortlist[0], 64);
+  if (!shortlist.empty()) {
+    ABORT_IF(!marian::data::isBinaryShortlist(shortlist[0]),
+             "Loading non-binary shortlist file into memory is not supported");
+    return loadFileToMemory(shortlist[0], 64);
+  }
+  return AlignedMemory();
 }
 
 void getVocabsMemoryFromConfig(marian::Ptr<marian::Options> options,
@@ -143,10 +145,7 @@ AlignedMemory getQualityEstimatorModel(MemoryBundle& memoryBundle, const marian:
 MemoryBundle getMemoryBundleFromConfig(marian::Ptr<marian::Options> options) {
   MemoryBundle memoryBundle;
   memoryBundle.model = getModelMemoryFromConfig(options);
-  auto shortlist = options->get<std::vector<std::string>>("shortlist");
-  if (!shortlist.empty()) {
-    memoryBundle.shortlist = getShortlistMemoryFromConfig(options);
-  }
+  memoryBundle.shortlist = getShortlistMemoryFromConfig(options);
   getVocabsMemoryFromConfig(options, memoryBundle.vocabs);
   memoryBundle.ssplitPrefixFile = getSsplitPrefixFileMemoryFromConfig(options);
   memoryBundle.qualityEstimatorMemory = getQualityEstimatorModel(options);

--- a/src/translator/byte_array_util.cpp
+++ b/src/translator/byte_array_util.cpp
@@ -143,7 +143,10 @@ AlignedMemory getQualityEstimatorModel(MemoryBundle& memoryBundle, const marian:
 MemoryBundle getMemoryBundleFromConfig(marian::Ptr<marian::Options> options) {
   MemoryBundle memoryBundle;
   memoryBundle.model = getModelMemoryFromConfig(options);
-  memoryBundle.shortlist = getShortlistMemoryFromConfig(options);
+  auto shortlist = options->get<std::vector<std::string>>("shortlist");
+  if (!shortlist.empty()) {
+    memoryBundle.shortlist = getShortlistMemoryFromConfig(options);
+  }
   getVocabsMemoryFromConfig(options, memoryBundle.vocabs);
   memoryBundle.ssplitPrefixFile = getSsplitPrefixFileMemoryFromConfig(options);
   memoryBundle.qualityEstimatorMemory = getQualityEstimatorModel(options);

--- a/src/translator/service.h
+++ b/src/translator/service.h
@@ -127,10 +127,9 @@ class AsyncService {
 
   /// Create a TranslationModel compatible with this instance of Service. Internally assigns how many replicas of
   /// backend needed based on worker threads set. See TranslationModel for documentation on other params.
-  template <class ConfigType>
-  Ptr<TranslationModel> createCompatibleModel(const ConfigType &config, MemoryBundle &&memory = MemoryBundle{}) {
+  Ptr<TranslationModel> createCompatibleModel(const TranslationModel::Config &config) {
     // @TODO: Remove this remove this dependency/coupling.
-    return New<TranslationModel>(config, std::move(memory), /*replicas=*/config_.numWorkers);
+    return New<TranslationModel>(config, /*replicas=*/config_.numWorkers);
   }
 
   /// With the supplied TranslationModel, translate an input. A Response is constructed with optional items set/unset

--- a/src/translator/translation_model.h
+++ b/src/translator/translation_model.h
@@ -6,6 +6,7 @@
 
 #include "batch.h"
 #include "batching_pool.h"
+#include "byte_array_util.h"
 #include "cache.h"
 #include "common/utils.h"
 #include "data/shortlist.h"
@@ -56,7 +57,10 @@ class TranslationModel {
   /// @param [in] options: Marian options object.
   /// @param [in] memory: MemoryBundle object holding memory buffers containing parameters to build MarianBackend,
   /// ShortlistGenerator, Vocabs and SentenceSplitter.
-  TranslationModel(const Config& options, MemoryBundle&& memory = MemoryBundle{}, size_t replicas = 1);
+  TranslationModel(const Config& options, MemoryBundle&& memory, size_t replicas = 1);
+
+  TranslationModel(const Config& options, size_t replicas = 1)
+      : TranslationModel(options, getMemoryBundleFromConfig(options), replicas) {}
 
   /// Make a Request to be translated by this TranslationModel instance.
   /// @param [in] requestId: Unique identifier associated with this request, available from Service.


### PR DESCRIPTION
Provides an additional constructor which takes care of the bundle loading inside the boundary of the source here, when a configuration file is supplied from a client like translateLocally or python bindings.  Once the config file is read, we have access to the information required to construct the `MemoryBundle`.

- The command-line application supplied from here, `app/bergamot` is configured to use the fast-load path now.
- Changes to binary-loading additionally revealed a bug in the example-run script used in docs and tied to CI and the fix is included.
-  Shortlist is made optional in the memory-bundle, making changes to `getModelMemoryFromConfig`.

Fixes #304.
Fixes #306.
See also: XapaJIaMnu/translateLocally#82.

PS: There is a need to refactor of `byte_array_utils`, aggressive reduction of paths and branches and consolidation of existing fragmented functions into manageable classes, but keeping this PR minimal to simplify review.