### PR TITLE
Response error fields

### DIFF
--- a/src/tests/common-impl.cpp
+++ b/src/tests/common-impl.cpp
@@ -9,7 +9,7 @@ Response Bridge<BlockingService>::translate(BlockingService &service, std::share
   // vector<Response>, return.
   std::vector<std::string> sources = {source};
   Response response = std::move(service.translateMultiple(model, std::move(sources), responseOptions).front());
-  ABORT_IF(!response.ok(), "Error in response:", response.error);
+  ABORT_IF(!response.ok(), "Error in response: {}", response.error);
   return response;
 }
 
@@ -25,7 +25,7 @@ Response Bridge<AsyncService>::translate(AsyncService &service, std::shared_ptr<
   responseFuture.wait();
 
   Response response = responseFuture.get();
-  ABORT_IF(!response.ok(), "Error in response:", response.error);
+  ABORT_IF(!response.ok(), "Error in response: {}", response.error);
   return response;
 }
 

--- a/src/tests/common-impl.cpp
+++ b/src/tests/common-impl.cpp
@@ -8,7 +8,9 @@ Response Bridge<BlockingService>::translate(BlockingService &service, std::share
   // project source to a vector of std::string, send in, unpack the first element from
   // vector<Response>, return.
   std::vector<std::string> sources = {source};
-  return service.translateMultiple(model, std::move(sources), responseOptions).front();
+  Response response = std::move(service.translateMultiple(model, std::move(sources), responseOptions).front());
+  ABORT_IF(!response.ok(), "Error in response:", response.error);
+  return response;
 }
 
 Response Bridge<AsyncService>::translate(AsyncService &service, std::shared_ptr<TranslationModel> &model,
@@ -23,6 +25,7 @@ Response Bridge<AsyncService>::translate(AsyncService &service, std::shared_ptr<
   responseFuture.wait();
 
   Response response = responseFuture.get();
+  ABORT_IF(!response.ok(), "Error in response:", response.error);
   return response;
 }
 

--- a/src/translator/html.cpp
+++ b/src/translator/html.cpp
@@ -291,7 +291,7 @@ std::optional<HTML::Error> HTML::parse(std::string &source) {
   // If we encounter an error, clear our internal state so a call to restore()
   // doesn't do anything half-assed. Also undo any changes to `source` which
   // we got by reference. Finally format an error message.
-  auto fail = [&](auto &&...args) {
+  auto fail = [&](auto &&... args) {
     source = std::move(original);
     spans_.clear();
     pool_.clear();

--- a/src/translator/response.h
+++ b/src/translator/response.h
@@ -73,6 +73,23 @@ struct Response {
   const std::string &getOriginalText() const { return source.text; }
 
   const std::string &getTranslatedText() const { return target.text; }
+
+  /// Stores a possible error message if the translation request was
+  /// unsuccessful. Empty message means no error.
+  std::string error;
+
+  /// Test whether this request has not failed yet.
+  /// Shortcut for the empty-message-is-good semantics above.
+  bool ok() const { return error.empty(); }
+
+  /// Factory for creating an error response. Just a shortcut, setting an error
+  /// by changing the `Response.error` field is also valid.
+  inline static Response withError(std::string &&error) {
+    assert(!error.empty());
+    Response response;
+    response.error = std::move(error);
+    return response;
+  }
 };
 
 std::vector<Alignment> remapAlignments(const Response &first, const Response &second);

--- a/src/translator/service.cpp
+++ b/src/translator/service.cpp
@@ -50,11 +50,11 @@ std::vector<Response> BlockingService::translateMultiple(std::shared_ptr<Transla
   size_t j = 0;
   for (size_t i = 0; i < sources.size(); ++i) {
     if (!responseOptions.HTML) {
-      sources[j++] = std::move(sources[i]);
+      if (j++ != i) sources[j] = std::move(sources[i]);
     } else if (auto err = htmls[i].parse(sources[i])) {
       responses[i].error = err->message;
     } else {
-      sources[j++] = std::move(sources[i]);
+      if (j++ != i) sources[j] = std::move(sources[i]);
     }
   }
   sources.resize(j);  // Clip off all the failed parses

--- a/wasm/bindings/response_bindings.cpp
+++ b/wasm/bindings/response_bindings.cpp
@@ -25,6 +25,8 @@ std::vector<SentenceQualityScore> getQualityScores(const Response& response) { r
 EMSCRIPTEN_BINDINGS(response) {
   class_<Response>("Response")
       .constructor<>()
+      .property("ok", &Response::ok)
+      .property("error", &Response::error)
       .function("size", &Response::size)
       .function("getQualityScores", &getQualityScores)
       .function("getOriginalText", &Response::getOriginalText)

--- a/wasm/test_page/js/worker.js
+++ b/wasm/test_page/js/worker.js
@@ -245,6 +245,7 @@ const _translateInvolvingEnglish = (from, to, input) => {
   const vectorResponse = translationService.translate(translationModel, vectorSourceText, responseOptions);
 
   // Parse all relevant information from vectorResponse
+  _parseResponseErrors(vectorResponse);
   const listTranslatedText = _parseTranslatedText(vectorResponse);
   const listSourceText = _parseSourceText(vectorResponse);
   const listTranslatedTextSentences = _parseTranslatedTextSentences(vectorResponse);
@@ -261,6 +262,13 @@ const _translateInvolvingEnglish = (from, to, input) => {
   vectorSourceText.delete();
 
   return listTranslatedText;
+}
+
+const _parseResponseErrors = (vectorResponse) => {
+  for (let i = 0; i < vectorResponse.size(); i++) {
+    if (!vectorResponse.get(i).ok)
+      throw Error(`Request ${i} returned an error: ${vectorResponse.get(i).error}`);
+  }
 }
 
 const _parseTranslatedText = (vectorResponse) => {


### PR DESCRIPTION
Possible implementation that solves #316. I opened it as draft for feedback.

Problem: WASM bindings compiles Marian and bergamot-translator without exception support.

This pull request removes the exceptions thrown by HTML and replaces them with error return values. It also changes the services implementations a bit to translate these HTML errors into "error responses". 

Todo
- [x] Remove exceptions from HTML
- [x] Let {Blocking,Async}Service return an error response when HTML parsing fails
- [ ] Check for any other recoverable runtime exceptions we should handle this way
- [ ] Update cli utilities that use {Async,Blocking}Service for tests to handle not-ok responses
- [x] Expose response.ok and response.error to WASM
- [x] Look for response.ok in wasm demo page
- [ ] Expose response.ok and response.error to Python
