### PR TITLE
Fix HTML with pivoting 

### DIFF
--- a/src/tests/common-impl.cpp
+++ b/src/tests/common-impl.cpp
@@ -71,6 +71,8 @@ void TestSuite<Service>::TestSuite::run(const std::string &opModeAsString, std::
     translationCache(models.front());
   } else if (opModeAsString == "test-pivot") {
     pivotTranslate(models);
+  } else if (opModeAsString == "test-pivot-with-html") {
+    pivotTranslateWithHTML(models);
   } else if (opModeAsString == "test-html-translation") {
     htmlTranslation(models.front());
   } else {
@@ -224,6 +226,19 @@ void TestSuite<Service>::translationCache(Ptr<TranslationModel> model) {
            "same path, this is expected to be same.");
 
   std::cout << firstResponse.target.text;
+}
+
+template <class Service>
+void TestSuite<Service>::pivotTranslateWithHTML(std::vector<Ptr<TranslationModel>> &models) {
+  ABORT_IF(models.size() != 2, "Forward and backward test needs two models.");
+  ResponseOptions responseOptions;
+  responseOptions.HTML = true;
+  std::string source = readFromStdin();
+  std::promise<Response> responsePromise;
+  std::future<Response> responseFuture = responsePromise.get_future();
+  Response response = bridge_.pivot(service_, models.front(), models.back(), std::move(source), responseOptions);
+  std::cout << response.source.text;
+  std::cout << response.target.text;
 }
 
 template <class Service>

--- a/src/tests/common.h
+++ b/src/tests/common.h
@@ -88,6 +88,8 @@ class TestSuite {
 
   void pivotTranslate(std::vector<Ptr<TranslationModel>> &models);
 
+  void pivotTranslateWithHTML(std::vector<Ptr<TranslationModel>> &models);
+
   void htmlTranslation(Ptr<TranslationModel> model);
 };
 

--- a/src/translator/service.cpp
+++ b/src/translator/service.cpp
@@ -81,6 +81,11 @@ std::vector<Response> BlockingService::pivotMultiple(std::shared_ptr<Translation
                                                      std::shared_ptr<TranslationModel> second,
                                                      std::vector<std::string> &&sources,
                                                      const ResponseOptions &responseOptions) {
+  std::vector<HTML> htmls;
+  for (auto &&source : sources) {
+    htmls.emplace_back(std::move(source), responseOptions.HTML);
+  }
+
   // Translate source to pivots. This is same as calling translateMultiple.
   std::vector<Response> sourcesToPivots;
   sourcesToPivots = translateMultipleRaw(first, std::move(sources), responseOptions);
@@ -113,6 +118,10 @@ std::vector<Response> BlockingService::pivotMultiple(std::shared_ptr<Translation
   for (size_t i = 0; i < sourcesToPivots.size(); i++) {
     Response finalResponse = combine(std::move(sourcesToPivots[i]), std::move(pivotsToTargets[i]));
     finalResponses.push_back(std::move(finalResponse));
+  }
+
+  for (size_t i = 0; i < finalResponses.size(); i++) {
+    htmls[i].restore(finalResponses[i]);
   }
 
   return finalResponses;


### PR DESCRIPTION
Previously BlockingService pivoting missed preproc and postproc for HTML leading to issues in WebAssembly API. This change adds fixes for the same, along with test coverage for the functionality over both async and blocking services. 