### PR TITLE
Make default throw exception on abort for python

### DIFF
--- a/bindings/python/bergamot.cpp
+++ b/bindings/python/bergamot.cpp
@@ -33,7 +33,10 @@ PYBIND11_MAKE_OPAQUE(Alignments);
 
 class ServicePyAdapter {
  public:
-  ServicePyAdapter(const Service::Config &config) : service_(make_service(config)) {}
+  ServicePyAdapter(const Service::Config &config) : service_(make_service(config)) {
+    // Set marian to throw exceptions instead of std::abort()
+    marian::setThrowExceptionOnAbort(true);
+  }
 
   std::shared_ptr<_Model> modelFromConfig(const std::string &config) {
     auto parsedConfig = marian::bergamot::parseOptionsFromString(config);

--- a/src/translator/service.cpp
+++ b/src/translator/service.cpp
@@ -37,10 +37,7 @@ BlockingService::BlockingService(const BlockingService::Config &config)
       requestId_(0),
       batchingPool_(),
       cache_(config.cacheSize, /*mutexBuckets=*/1),
-      logger_(config.logger) {
-  // Set marian to throw exceptions instead of std::abort()
-  marian::setThrowExceptionOnAbort(true);
-}
+      logger_(config.logger) {}
 
 std::vector<Response> BlockingService::translateMultiple(std::shared_ptr<TranslationModel> translationModel,
                                                          std::vector<std::string> &&sources,
@@ -136,8 +133,6 @@ AsyncService::AsyncService(const AsyncService::Config &config)
       safeBatchingPool_(),
       cache_(config_.cacheSize, config_.cacheMutexBuckets),
       logger_(config.logger) {
-  // Set marian to throw exceptions instead of std::abort()
-  marian::setThrowExceptionOnAbort(true);
   ABORT_IF(config_.numWorkers == 0, "Number of workers should be at least 1 in a threaded workflow");
   workers_.reserve(config_.numWorkers);
   for (size_t cpuId = 0; cpuId < config_.numWorkers; cpuId++) {

--- a/src/translator/service.cpp
+++ b/src/translator/service.cpp
@@ -37,7 +37,10 @@ BlockingService::BlockingService(const BlockingService::Config &config)
       requestId_(0),
       batchingPool_(),
       cache_(config.cacheSize, /*mutexBuckets=*/1),
-      logger_(config.logger) {}
+      logger_(config.logger) {
+  // Set marian to throw exceptions instead of std::abort()
+  marian::setThrowExceptionOnAbort(true);
+}
 
 std::vector<Response> BlockingService::translateMultiple(std::shared_ptr<TranslationModel> translationModel,
                                                          std::vector<std::string> &&sources,
@@ -133,6 +136,8 @@ AsyncService::AsyncService(const AsyncService::Config &config)
       safeBatchingPool_(),
       cache_(config_.cacheSize, config_.cacheMutexBuckets),
       logger_(config.logger) {
+  // Set marian to throw exceptions instead of std::abort()
+  marian::setThrowExceptionOnAbort(true);
   ABORT_IF(config_.numWorkers == 0, "Number of workers should be at least 1 in a threaded workflow");
   workers_.reserve(config_.numWorkers);
   for (size_t cpuId = 0; cpuId < config_.numWorkers; cpuId++) {


### PR DESCRIPTION
As a library, this is the more sane default. This also allows the
mechanism to convert into runtime errors in python, providing
informative messages to the user via pybind11 existing tooling.