### PR TITLE
Add ability to load `.npz` models 

### DIFF
--- a/src/translator/byte_array_util.cpp
+++ b/src/translator/byte_array_util.cpp
@@ -1,9 +1,9 @@
 #include "byte_array_util.h"
-#include "common/io.h"
 
 #include <cstdlib>
 #include <memory>
 
+#include "common/io.h"
 #include "data/shortlist.h"
 
 namespace marian {

--- a/src/translator/byte_array_util.cpp
+++ b/src/translator/byte_array_util.cpp
@@ -94,13 +94,16 @@ AlignedMemory loadFileToMemory(const std::string& path, size_t alignment) {
 AlignedMemory getModelMemoryFromConfig(marian::Ptr<marian::Options> options) {
   auto models = options->get<std::vector<std::string>>("models");
   ABORT_IF(models.size() != 1, "Loading multiple binary models is not supported for now as it is not necessary.");
+
+  // If binary model we load into aligned memory. If .npz we leave it be to
+  // return empty aligned memory, thus allowing traditional file system loads.
   if (marian::io::isBin(models[0])) {
     AlignedMemory alignedMemory = loadFileToMemory(models[0], 256);
     return alignedMemory;
   } else if (marian::io::isNpz(models[0])) {
     return AlignedMemory();
   } else {
-    ABORT("Unknown extension for model: {}", models[0]);
+    ABORT("Unknown extension for model: {}, should be one of `.bin` or `.npz`", models[0]);
   }
   return AlignedMemory();
 }


### PR DESCRIPTION
Changes `ABORT` on non `.bin` model to an additional check for a `.npz` 
extension. If `.bin`, the fast load path is activated by returning `AlignedMemory`. 
Otherwise, the return of empty `AlignedMemory` causes fallback to
filesystem-based loads.

BRT: A test that checks if translation using `.npz` is approximately similar to 
that of default CLI translation is checked in to ensure stability going ahead.

Previously, we only supported `.bin` models' loading via a fast mmap 
path. While we had the underlying capability to load non `.bin` models, this 
was not exposed, encouraging fast loads. Loading `.npz` models are helpful 
for quick debugging and broader coverage of models available, which will 
enhance user experience at translateLocally and python bindings. 


Fixes #341.
See also: XapaJIaMnu/translateLocally#89