### PR TITLE
Print errors by default in WASM build

### DIFF
--- a/src/tests/units/html_tests.cpp
+++ b/src/tests/units/html_tests.cpp
@@ -10,6 +10,17 @@
 using namespace marian::bergamot;
 using marian::string_view;
 
+class MarianThrowsExceptionsFixture {
+ protected:
+  MarianThrowsExceptionsFixture() : prev_(marian::getThrowExceptionOnAbort()) {
+    marian::setThrowExceptionOnAbort(true);
+  }
+  ~MarianThrowsExceptionsFixture() { marian::setThrowExceptionOnAbort(prev_); }
+
+ private:
+  bool prev_;
+};
+
 std::ostream &operator<<(std::ostream &out, std::pair<ByteRange, ByteRange> const &b) {
   return out << '(' << b.first << ',' << b.second << ')';
 }
@@ -76,9 +87,7 @@ TEST_CASE("Ignore HTML if process_markup is false") {
   CHECK(response.source.text == html_code);
 }
 
-TEST_CASE("Abort if alignments are missing") {
-  marian::setThrowExceptionOnAbort(true);
-
+TEST_CASE_METHOD(MarianThrowsExceptionsFixture, "Abort if alignments are missing") {
   std::string input("<p>hello <b>world</b></p>\n");
   HTML html(std::move(input), true);
 
@@ -108,9 +117,7 @@ TEST_CASE("Abort if alignments are missing") {
       "Response object does not contain alignments. TranslationModel or ResponseOptions is misconfigured?");
 }
 
-TEST_CASE("Abort if alignments are misconfigured") {
-  marian::setThrowExceptionOnAbort(true);
-
+TEST_CASE_METHOD(MarianThrowsExceptionsFixture, "Abort if alignments are misconfigured") {
   std::string input("<p>hello <b>world</b></p>\n");
   HTML html(std::move(input), true);
 

--- a/src/translator/html.h
+++ b/src/translator/html.h
@@ -14,11 +14,6 @@ namespace bergamot {
 
 struct Response;
 
-class BadHTML : public std::runtime_error {
- public:
-  explicit BadHTML(std::string const &what) : std::runtime_error(what) {}
-};
-
 class HTML {
  public:
   struct Options {

--- a/wasm/bindings/service_bindings.cpp
+++ b/wasm/bindings/service_bindings.cpp
@@ -75,9 +75,15 @@ EMSCRIPTEN_BINDINGS(blocking_service_config) {
   // aggregate-batching etc.
 }
 
+std::shared_ptr<BlockingService> BlockingServiceFactory(const BlockingService::Config& config) {
+  auto copy = config;
+  copy.logger.level = "critical";
+  return std::make_shared<BlockingService>(copy);
+}
+
 EMSCRIPTEN_BINDINGS(blocking_service) {
   class_<BlockingService>("BlockingService")
-      .constructor<BlockingService::Config>()
+      .smart_ptr_constructor("BlockingService", &BlockingServiceFactory)
       .function("translate", &BlockingService::translateMultiple)
       .function("translateViaPivoting", &BlockingService::pivotMultiple);
 


### PR DESCRIPTION
This change makes sure that errors are printed to the console in the WASM build. It also replaces the exceptions in `HTML` with `ABORT` macros to make sure something helpful is printed when they occur.

Note that the `onerror` handler is still called without an error message since it is just a forwarded call of `std::abort()`. Even if you hook into `onAbort`, it is called without arguments. However, if you do want to catch the error messages, you can hook into `printErr` which catches everything written to `std::cerr`. Which, thanks to the new default logging level, includes the exception message.

I've not changed this in `worker.js` because the default behaviour—print warnings to the terminal—is sufficient there. However, the example below might be useful for telemetry or Sentry integration.

Example (see worker.js for context)
```js
var Module = {
  // as is currently in worker.js...
  onRuntimeInitialized: function() {
    // ...
    importScripts(MODEL_REGISTRY);
    postMessage([`import_reply`, modelRegistry]);
  },
  onAbort: function() {
    // std::abort() was called, probably due to an exception
  },
  printErr: function(message) {
    // if that was the case, then this callback was called moments before
    // it one or more times with each a single line of error message.
    console.error('Module::err', message);
  }
};
```

<img width="1634" alt="image" src="https://user-images.githubusercontent.com/198639/153052098-d350e888-c65b-42e6-8fd2-2bd448199993.png">
