### PR TITLE
Create github release via CircleCI only for mozilla fork

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,20 +82,24 @@ jobs:
           destination: "wasm-without-wormhole"
 
   publish_to_github:
-     docker:
-       - image: cibuilds/github:0.10
-     steps:
-       - attach_workspace:
+    docker:
+      - image: cibuilds/github:0.10
+    steps:
+      - attach_workspace:
           # Must be absolute path or relative path from working_directory
           at: ./
-       - run:
-          name: "Publish Release on GitHub"
-          command: |
-            export TAG_VERSION=$(cat ./artifacts/BERGAMOT_VERSION)
-            ls -lsa ./artifacts/ > ./artifacts/FILESIZES
-            cat ./artifacts/SHA256-1 ./artifacts/SHA256-2 > ./artifacts/SHA256
-            rm ./artifacts/SHA256-1 ./artifacts/SHA256-2 ./artifacts/BERGAMOT_VERSION
-            ghr -t ${GHTOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${TAG_VERSION} ./artifacts/
+      - when:
+          condition:
+            equal: [ 'https://github.com/mozilla/bergamot-translator', << pipeline.project.git_url >> ]
+          steps:
+            - run:
+                name: "Publish Release on GitHub"
+                command: |
+                  export TAG_VERSION=$(cat ./artifacts/BERGAMOT_VERSION)
+                  ls -lsa ./artifacts/ > ./artifacts/FILESIZES
+                  cat ./artifacts/SHA256-1 ./artifacts/SHA256-2 > ./artifacts/SHA256
+                  rm ./artifacts/SHA256-1 ./artifacts/SHA256-2 ./artifacts/BERGAMOT_VERSION
+                  ghr -t ${GHTOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${TAG_VERSION} ./artifacts/
 
 workflows:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,13 +20,18 @@ jobs:
           working_directory: build-wasm
           command: |
             ARTIFACT_BASE="bergamot-translator-worker"
+            ARTIFACT_SUFFIX="with-wormhole"
+            ARTIFACT_FINAL=$ARTIFACT_BASE-$ARTIFACT_SUFFIX
+
             if [[ -f "$ARTIFACT_BASE.js" && -f "$ARTIFACT_BASE.wasm" ]]; then
               echo "Artifacts Successfully Generated"
               mkdir ../artifacts
-              cp $ARTIFACT_BASE.wasm ../artifacts/$ARTIFACT_BASE-with-wormhole.wasm
-              cp $ARTIFACT_BASE.js ../artifacts/$ARTIFACT_BASE-with-wormhole.js
-              shasum -a 256 ../artifacts/* > ../artifacts/SHA256-1
-              cp ../BERGAMOT_VERSION ../artifacts/
+              cp $ARTIFACT_BASE.wasm ../artifacts/$ARTIFACT_FINAL.wasm
+              cp $ARTIFACT_BASE.js ../artifacts/$ARTIFACT_FINAL.js
+              cd ../artifacts
+              shasum -a 256 $ARTIFACT_FINAL.wasm $ARTIFACT_FINAL.js >> sha256-filesize-$ARTIFACT_SUFFIX
+              ls -lsa $ARTIFACT_FINAL.wasm $ARTIFACT_FINAL.js >> sha256-filesize-$ARTIFACT_SUFFIX
+              cp ../BERGAMOT_VERSION .
             else
               echo "Failure: Artifacts Not Present"
               exit 1
@@ -61,12 +66,17 @@ jobs:
           working_directory: build-wasm
           command: |
             ARTIFACT_BASE="bergamot-translator-worker"
+            ARTIFACT_SUFFIX="without-wormhole"
+            ARTIFACT_FINAL=$ARTIFACT_BASE-$ARTIFACT_SUFFIX
+
             if [[ -f "$ARTIFACT_BASE.js" && -f "$ARTIFACT_BASE.wasm" ]]; then
               echo "Artifacts Successfully Generated"
               mkdir ../artifacts
-              cp $ARTIFACT_BASE.wasm ../artifacts/$ARTIFACT_BASE-without-wormhole.wasm
-              cp $ARTIFACT_BASE.js ../artifacts/$ARTIFACT_BASE-without-wormhole.js
-              shasum -a 256 ../artifacts/* > ../artifacts/SHA256-2
+              cp $ARTIFACT_BASE.wasm ../artifacts/$ARTIFACT_FINAL.wasm
+              cp $ARTIFACT_BASE.js ../artifacts/$ARTIFACT_FINAL.js
+              cd ../artifacts
+              shasum -a 256 $ARTIFACT_FINAL.wasm $ARTIFACT_FINAL.js >> sha256-filesize-$ARTIFACT_SUFFIX
+              ls -lsa $ARTIFACT_FINAL.wasm $ARTIFACT_FINAL.js >> sha256-filesize-$ARTIFACT_SUFFIX
             else
               echo "Failure: Artifacts Not Present"
               exit 1
@@ -96,9 +106,8 @@ jobs:
                 name: "Publish Release on GitHub"
                 command: |
                   export TAG_VERSION=$(cat ./artifacts/BERGAMOT_VERSION)
-                  ls -lsa ./artifacts/ > ./artifacts/FILESIZES
-                  cat ./artifacts/SHA256-1 ./artifacts/SHA256-2 > ./artifacts/SHA256
-                  rm ./artifacts/SHA256-1 ./artifacts/SHA256-2 ./artifacts/BERGAMOT_VERSION
+                  cat ./artifacts/sha256-filesize-without-wormhole ./artifacts/sha256-filesize-with-wormhole >> ./artifacts/sha256-filesize
+                  rm ./artifacts/sha256-filesize-without-wormhole ./artifacts/sha256-filesize-with-wormhole ./artifacts/BERGAMOT_VERSION
                   ghr -t ${GHTOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${TAG_VERSION} ./artifacts/
 
 workflows:


### PR DESCRIPTION
Fixes https://github.com/browsermt/bergamot-translator/issues/335

The extension uses translator artifacts build in mozilla fork. Therefore, create github release via circleci only when running in mozilla fork.

Tested it here: https://app.circleci.com/pipelines/github/abhi-agg/bergamot-translator/96/workflows/10b2a8b5-32c0-4f36-abc1-1c379a1b876c