### PR TITLE
Store subword indices for quality scores in Response

### DIFF
--- a/src/tests/common-impl.cpp
+++ b/src/tests/common-impl.cpp
@@ -159,9 +159,7 @@ void TestSuite<Service>::qualityEstimatorWords(Ptr<TranslationModel> model) {
     const auto &sentenceQualityEstimate = response.qualityScores[sentenceIdx];
     std::cout << "[SentenceBegin]\n";
 
-    for (const auto &wordRange : sentenceQualityEstimate.wordRanges) {
-      const ByteRange wordByteRange{response.target.wordAsByteRange(sentenceIdx, wordRange.begin).begin,
-                                    response.target.wordAsByteRange(sentenceIdx, wordRange.end).begin};
+    for (const auto &wordByteRange : getWordByteRanges(response, sentenceIdx)) {
       const string_view word(response.target.text.data() + wordByteRange.begin, wordByteRange.size());
       std::cout << word << "\n";
     }

--- a/src/tests/common-impl.cpp
+++ b/src/tests/common-impl.cpp
@@ -155,10 +155,13 @@ void TestSuite<Service>::qualityEstimatorWords(Ptr<TranslationModel> model) {
   std::string source = readFromStdin();
   const Response response = bridge_.translate(service_, model, std::move(source), responseOptions);
 
-  for (const auto &sentenceQualityEstimate : response.qualityScores) {
+  for (size_t sentenceIdx = 0; sentenceIdx < response.qualityScores.size(); ++sentenceIdx) {
+    const auto &sentenceQualityEstimate = response.qualityScores[sentenceIdx];
     std::cout << "[SentenceBegin]\n";
 
-    for (const auto &wordByteRange : sentenceQualityEstimate.wordByteRanges) {
+    for (const auto &wordRange : sentenceQualityEstimate.wordRanges) {
+      const ByteRange wordByteRange{response.target.wordAsByteRange(sentenceIdx, wordRange.begin).begin,
+                                    response.target.wordAsByteRange(sentenceIdx, wordRange.end).begin};
       const string_view word(response.target.text.data() + wordByteRange.begin, wordByteRange.size());
       std::cout << word << "\n";
     }

--- a/src/translator/definitions.h
+++ b/src/translator/definitions.h
@@ -42,6 +42,16 @@ struct ByteRange {
   bool operator==(ByteRange other) const { return begin == other.begin && end == other.end; }
 };
 
+/// A Subword range is mechanically the same as a `ByteRange`, but instead of
+/// describing a span of bytes, it describes a span of Subword tokens. Using
+/// `Annotation.word()` you can switch between the two.
+struct SubwordRange {
+  size_t begin;
+  size_t end;
+  const size_t size() const { return end - begin; }
+  bool operator==(SubwordRange other) const { return begin == other.begin && end == other.end; }
+};
+
 class Response;
 using CallbackType = std::function<void(Response &&)>;
 

--- a/src/translator/quality_estimator.cpp
+++ b/src/translator/quality_estimator.cpp
@@ -27,7 +27,7 @@ Response::SentenceQualityScore UnsupervisedQualityEstimator::computeSentenceScor
   const float sentenceScore =
       std::accumulate(std::begin(wordScores), std::end(wordScores), float(0.0)) / wordScores.size();
 
-  return {wordScores, subwordToWords(wordIndices, target, sentenceIdx), sentenceScore};
+  return {wordScores, wordIndices, sentenceScore};
 }
 
 LogisticRegressorQualityEstimator::Matrix::Matrix(const size_t rowsParam, const size_t colsParam)
@@ -160,7 +160,7 @@ Response::SentenceQualityScore LogisticRegressorQualityEstimator::computeSentenc
   const float sentenceScore =
       std::accumulate(std::begin(wordScores), std::end(wordScores), float(0.0)) / wordScores.size();
 
-  return {wordScores, subwordToWords(wordIndices, target, sentenceIdx), sentenceScore};
+  return {wordScores, wordIndices, sentenceScore};
 }
 
 std::vector<float> LogisticRegressorQualityEstimator::predict(const Matrix& features) const {
@@ -265,24 +265,6 @@ std::vector<SubwordRange> mapWords(const std::vector<float>& logProbs, const Ann
   wordIndices.back().end = logProbs.size() - 1;
 
   return wordIndices;
-}
-
-std::vector<ByteRange> subwordToWords(const std::vector<SubwordRange>& wordIndices, const AnnotatedText& target,
-                                      const size_t sentenceIdx) {
-  std::vector<ByteRange> words;
-
-  for (const SubwordRange& wordIndice : wordIndices) {
-    size_t wordBegin = target.wordAsByteRange(sentenceIdx, wordIndice.begin).begin;
-    size_t wordEnd = target.wordAsByteRange(sentenceIdx, wordIndice.end).begin;
-
-    if (isspace(target.text.at(wordBegin))) {
-      ++wordBegin;
-    }
-
-    words.emplace_back(ByteRange{wordBegin, wordEnd});
-  }
-
-  return words;
 }
 
 }  // namespace marian::bergamot

--- a/src/translator/quality_estimator.h
+++ b/src/translator/quality_estimator.h
@@ -21,8 +21,6 @@ class QualityEstimator {
   virtual void computeQualityScores(const Histories &histories, Response &response) const = 0;
 };
 
-using SubwordRange = ByteRange;
-
 /// Unsupervised Quality Estimator model. It uses the translator model's log probabilities (log probs) as a proxy for
 /// quality scores. Then, for a given word, its quality score is computed by taking the mean of the log probs of the
 /// tokens that make it up. The sentence score is the mean of all word's log probs.
@@ -208,15 +206,5 @@ inline std::shared_ptr<QualityEstimator> createQualityEstimator(const AlignedMem
 /// @param [in] sentenceIdx: the id of a candidate sentence
 std::vector<SubwordRange> mapWords(const std::vector<float> &logProbs, const AnnotatedText &target,
                                    const size_t sentenceIdx);
-
-/// Given a vector of subwordRanges, it maps the elements to be real words rather than sublevel tokens. The words are
-/// represented through ByteRanges.
-
-/// @param [in] wordIndices: A vector where each element correspond to the index of a real word and its values are
-/// represented by the SubwordRanges (which are aliases of ByteRanges) which represents sublevel token positions
-/// @param [in] target: AnnotatedText target value
-/// @param [in] sentenceIdx: the id of a candidate sentence
-std::vector<ByteRange> subwordToWords(const std::vector<SubwordRange> &wordIndices, const AnnotatedText &target,
-                                      const size_t sentenceIdx);
 
 }  // namespace marian::bergamot

--- a/src/translator/response.cpp
+++ b/src/translator/response.cpp
@@ -142,4 +142,22 @@ std::vector<Alignment> remapAlignments(const Response &first, const Response &se
   return alignments;
 }
 
+std::vector<ByteRange> getWordByteRanges(const Response &response, size_t sentenceIdx) {
+  std::vector<ByteRange> wordByteRanges;
+  wordByteRanges.reserve(response.qualityScores[sentenceIdx].wordRanges.size());
+
+  for (auto &&word : response.qualityScores[sentenceIdx].wordRanges) {
+    size_t wordBegin = response.target.wordAsByteRange(sentenceIdx, word.begin).begin;
+    size_t wordEnd = response.target.wordAsByteRange(sentenceIdx, word.end).begin;
+
+    if (std::isspace(response.target.text.at(wordBegin))) {
+      ++wordBegin;
+    }
+
+    wordByteRanges.emplace_back(ByteRange{wordBegin, wordEnd});
+  }
+
+  return wordByteRanges;
+}
+
 }  // namespace marian::bergamot

--- a/src/translator/response.h
+++ b/src/translator/response.h
@@ -77,6 +77,8 @@ struct Response {
 
 std::vector<Alignment> remapAlignments(const Response &first, const Response &second);
 
+std::vector<ByteRange> getWordByteRanges(Response const &response, size_t sentenceIdx);
+
 }  // namespace bergamot
 }  // namespace marian
 

--- a/src/translator/response.h
+++ b/src/translator/response.h
@@ -30,8 +30,8 @@ struct Response {
   struct SentenceQualityScore {
     /// Quality score of each translated word
     std::vector<float> wordScores;
-    /// Each word position in the translated text
-    std::vector<ByteRange> wordByteRanges;
+    /// Position of start and end token of each word in the translated text
+    std::vector<SubwordRange> wordRanges;
     /// Whole sentence quality score (it is composed by the mean of its words)
     float sentenceScore = 0.0;
   };

--- a/wasm/bindings/response_bindings.cpp
+++ b/wasm/bindings/response_bindings.cpp
@@ -35,21 +35,8 @@ std::vector<SentenceQualityScore> getQualityScores(const Response& response) {
   scores.reserve(response.qualityScores.size());
 
   for (size_t sentenceIdx = 0; sentenceIdx < response.qualityScores.size(); ++sentenceIdx) {
-    std::vector<ByteRange> wordByteRanges;
-    wordByteRanges.reserve(response.qualityScores[sentenceIdx].wordRanges.size());
-
-    for (auto&& word : response.qualityScores[sentenceIdx].wordRanges) {
-      size_t wordBegin = response.target.wordAsByteRange(sentenceIdx, word.begin).begin;
-      size_t wordEnd = response.target.wordAsByteRange(sentenceIdx, word.end).begin;
-
-      if (std::isspace(response.target.text.at(wordBegin))) {
-        ++wordBegin;
-      }
-
-      wordByteRanges.emplace_back(ByteRange{wordBegin, wordEnd});
-    }
-
-    scores.emplace_back(SentenceQualityScore{response.qualityScores[sentenceIdx].wordScores, std::move(wordByteRanges),
+    scores.emplace_back(SentenceQualityScore{response.qualityScores[sentenceIdx].wordScores,
+                                             marian::bergamot::getWordByteRanges(response, sentenceIdx),
                                              response.qualityScores[sentenceIdx].sentenceScore});
   }
 

--- a/wasm/bindings/response_bindings.cpp
+++ b/wasm/bindings/response_bindings.cpp
@@ -39,9 +39,14 @@ std::vector<SentenceQualityScore> getQualityScores(const Response& response) {
     wordByteRanges.reserve(response.qualityScores[sentenceIdx].wordRanges.size());
 
     for (auto&& word : response.qualityScores[sentenceIdx].wordRanges) {
-      wordByteRanges.emplace_back();
-      wordByteRanges.back().begin = response.target.wordAsByteRange(sentenceIdx, word.begin).begin;
-      wordByteRanges.back().end = response.target.wordAsByteRange(sentenceIdx, word.end).begin;
+      size_t wordBegin = response.target.wordAsByteRange(sentenceIdx, word.begin).begin;
+      size_t wordEnd = response.target.wordAsByteRange(sentenceIdx, word.end).begin;
+
+      if (std::isspace(response.target.text.at(wordBegin))) {
+        ++wordBegin;
+      }
+
+      wordByteRanges.emplace_back(ByteRange{wordBegin, wordEnd});
     }
 
     scores.emplace_back(SentenceQualityScore{response.qualityScores[sentenceIdx].wordScores, std::move(wordByteRanges),

--- a/wasm/test_page/js/worker.js
+++ b/wasm/test_page/js/worker.js
@@ -326,6 +326,7 @@ const _parseTranslatedTextSentenceQualityScores = (vectorResponse) => {
       sentenceQualityScores.push(sentenceQualityScore);
     }
     result.push(sentenceQualityScores);
+    vectorSentenceQualityScore.delete();
   }
   return result;
 }


### PR DESCRIPTION
Fixes #355 

This change stores the quality score per subword range instead of byte range in `Response`. When inserting HTML into the translation output, the byte offsets change but the subword offsets don't. 

I added a type for `SubwordRange` (previously just an alias for `ByteRange`) to avoid any confusion between the two. Now you can't compare or interchange them, even though they're both just ranges.

The WASM bindings still produce a SentenceQualityScore that works exactly the same as now, i.e. with ByteRanges. In #355 I mused that Javascript could access the byteranges per word through `response.target.wordAsByteRange()` but neither `response.target` nor the type `AnnotatedText` are currently exposed through the bindings. So to not introduce much more new API at this point, I made `getQualityScores()` return the same thing it always did.

Downside of this approach is that you'll need to `delete()` that returned object in Javascript land. I've changed `worker.js` to do this.