### PR TITLE
Bindings to control cache from JS

### DIFF
--- a/wasm/bindings/service_bindings.cpp
+++ b/wasm/bindings/service_bindings.cpp
@@ -69,10 +69,9 @@ EMSCRIPTEN_BINDINGS(translation_model) {
 }
 
 EMSCRIPTEN_BINDINGS(blocking_service_config) {
-  value_object<BlockingService::Config>("BlockingServiceConfig");
-  // .field("name", &BlockingService::Config::name")
-  // The above is a future hook. Note that more will come - for cache, for workspace-size or graph details  limits on
-  // aggregate-batching etc.
+  value_object<BlockingService::Config>("BlockingServiceConfig")
+      .field("cacheEnabled", &BlockingService::Config::cacheEnabled)
+      .field("cacheSize", &BlockingService::Config::cacheSize);
 }
 
 std::shared_ptr<BlockingService> BlockingServiceFactory(const BlockingService::Config& config) {

--- a/wasm/test_page/js/worker.js
+++ b/wasm/test_page/js/worker.js
@@ -78,7 +78,7 @@ onmessage = async function(e) {
 // Instantiates the Translation Service
 const constructTranslationService = async () => {
   if (!translationService) {
-    var translationServiceConfig = {};
+    var translationServiceConfig = {cacheEnabled: true, cacheSize: 20000};
     log(`Creating Translation Service with config: ${translationServiceConfig}`);
     translationService = new Module.BlockingService(translationServiceConfig);
     log(`Translation Service created successfully`);


### PR DESCRIPTION
Exposes the fields corresponding to cache via embind as a value object. 
The equivalent object-based syntax in `worker.js` allows propagation 
from JS.

Fixes: #351 
See also: mozilla/firefox-translations#96

--- 
The below screenshots are to demonstrate that cache is active and provide speedups in warm (exaggerated, but sufficient to demonstrate these changes work).

**Cold** 117 WPS

<img width="399" alt="image" src="https://user-images.githubusercontent.com/727292/154845471-b7c4fb4c-e645-44d1-95ab-bcbd8edff318.png">

**Warm** 5284 WPS

<img width="434" alt="image" src="https://user-images.githubusercontent.com/727292/154845500-47ac47ae-5830-43f4-b13a-a1d9c3f462e9.png">
