### PR TITLE
Use right range and threshold for showing "bad" words/sentences

### DIFF
--- a/wasm/test_page/js/index.js
+++ b/wasm/test_page/js/index.js
@@ -59,13 +59,13 @@ const addQualityClasses = (root) => {
   // You can do this wit CSS variables, calc() and min/max, but JS is just easier
 
   root.querySelectorAll('[x-bergamot-sentence-score]').forEach(el => {
-    // Note: these thresholds are just examples, they are not good thresholds!  
-    el.classList.toggle('bad', parseFloat(el.getAttribute('x-bergamot-sentence-score')) < -0.5);
+    // The threshold is ln(0.5) (https://github.com/browsermt/bergamot-translator/pull/370#issuecomment-1058123399)
+    el.classList.toggle('bad', parseFloat(el.getAttribute('x-bergamot-sentence-score')) < -0.6931);
   });
 
   root.querySelectorAll('[x-bergamot-word-score]').forEach(el => {
-    // Note: these thresholds are just examples, they are not good thresholds!
-    el.classList.toggle('bad', parseFloat(el.getAttribute('x-bergamot-word-score')) < -0.5);
+    // The threshold is ln(0.5) (https://github.com/browsermt/bergamot-translator/pull/370#issuecomment-1058123399)
+    el.classList.toggle('bad', parseFloat(el.getAttribute('x-bergamot-word-score')) < -0.6931);
   });
 
   // Add tooltips to each (sub)word with sentence and word score.

--- a/wasm/test_page/js/index.js
+++ b/wasm/test_page/js/index.js
@@ -60,12 +60,12 @@ const addQualityClasses = (root) => {
 
   root.querySelectorAll('[x-bergamot-sentence-score]').forEach(el => {
     // Note: these thresholds are just examples, they are not good thresholds!  
-    el.classList.toggle('bad', parseFloat(el.getAttribute('x-bergamot-sentence-score')) > -0.1);
+    el.classList.toggle('bad', parseFloat(el.getAttribute('x-bergamot-sentence-score')) < -0.5);
   });
 
   root.querySelectorAll('[x-bergamot-word-score]').forEach(el => {
     // Note: these thresholds are just examples, they are not good thresholds!
-    el.classList.toggle('bad', parseFloat(el.getAttribute('x-bergamot-word-score')) > -0.1);
+    el.classList.toggle('bad', parseFloat(el.getAttribute('x-bergamot-word-score')) < -0.5);
   });
 
   // Add tooltips to each (sub)word with sentence and word score.


### PR DESCRIPTION
Higher QE scores means better quality.
Changed the threshold to ~~`-0.5`~~ `ln(0.5) => -0.6931` as per discussions in QE meetings.

@mfomicheva @abarbosa94 @felipesantosk Please let me know if any of the above is wrong 👍🏾 