### PR TITLE
JS: Using supervised QE models for available language pairs

### DIFF
--- a/wasm/bindings/service_bindings.cpp
+++ b/wasm/bindings/service_bindings.cpp
@@ -45,11 +45,14 @@ std::vector<std::shared_ptr<AlignedMemory>> prepareVocabsSmartMemories(std::vect
 }
 
 MemoryBundle prepareMemoryBundle(AlignedMemory* modelMemory, AlignedMemory* shortlistMemory,
-                                 std::vector<AlignedMemory*> uniqueVocabsMemories) {
+                                 std::vector<AlignedMemory*> uniqueVocabsMemories, AlignedMemory* qeMemory) {
   MemoryBundle memoryBundle;
   memoryBundle.model = std::move(*modelMemory);
   memoryBundle.shortlist = std::move(*shortlistMemory);
   memoryBundle.vocabs = std::move(prepareVocabsSmartMemories(uniqueVocabsMemories));
+  if (qeMemory != nullptr) {
+    memoryBundle.qualityEstimatorMemory = std::move(*qeMemory);
+  }
 
   return memoryBundle;
 }
@@ -58,8 +61,8 @@ MemoryBundle prepareMemoryBundle(AlignedMemory* modelMemory, AlignedMemory* shor
 // https://emscripten.org/docs/porting/connecting_cpp_and_javascript/embind.html#smart-pointers
 std::shared_ptr<TranslationModel> TranslationModelFactory(const std::string& config, AlignedMemory* model,
                                                           AlignedMemory* shortlist,
-                                                          std::vector<AlignedMemory*> vocabs) {
-  MemoryBundle memoryBundle = prepareMemoryBundle(model, shortlist, vocabs);
+                                                          std::vector<AlignedMemory*> vocabs, AlignedMemory* qe = nullptr) {
+  MemoryBundle memoryBundle = prepareMemoryBundle(model, shortlist, vocabs, qe);
   return std::make_shared<TranslationModel>(config, std::move(memoryBundle));
 }
 

--- a/wasm/bindings/service_bindings.cpp
+++ b/wasm/bindings/service_bindings.cpp
@@ -45,13 +45,13 @@ std::vector<std::shared_ptr<AlignedMemory>> prepareVocabsSmartMemories(std::vect
 }
 
 MemoryBundle prepareMemoryBundle(AlignedMemory* modelMemory, AlignedMemory* shortlistMemory,
-                                 std::vector<AlignedMemory*> uniqueVocabsMemories, AlignedMemory* qeMemory) {
+                                 std::vector<AlignedMemory*> uniqueVocabsMemories, AlignedMemory* qualityEstimatorMemory) {
   MemoryBundle memoryBundle;
   memoryBundle.model = std::move(*modelMemory);
   memoryBundle.shortlist = std::move(*shortlistMemory);
   memoryBundle.vocabs = std::move(prepareVocabsSmartMemories(uniqueVocabsMemories));
-  if (qeMemory != nullptr) {
-    memoryBundle.qualityEstimatorMemory = std::move(*qeMemory);
+  if (qualityEstimatorMemory != nullptr) {
+    memoryBundle.qualityEstimatorMemory = std::move(*qualityEstimatorMemory);
   }
 
   return memoryBundle;
@@ -61,8 +61,8 @@ MemoryBundle prepareMemoryBundle(AlignedMemory* modelMemory, AlignedMemory* shor
 // https://emscripten.org/docs/porting/connecting_cpp_and_javascript/embind.html#smart-pointers
 std::shared_ptr<TranslationModel> TranslationModelFactory(const std::string& config, AlignedMemory* model,
                                                           AlignedMemory* shortlist,
-                                                          std::vector<AlignedMemory*> vocabs, AlignedMemory* qe = nullptr) {
-  MemoryBundle memoryBundle = prepareMemoryBundle(model, shortlist, vocabs, qe);
+                                                          std::vector<AlignedMemory*> vocabs, AlignedMemory* qualityEstimator) {
+  MemoryBundle memoryBundle = prepareMemoryBundle(model, shortlist, vocabs, qualityEstimator);
   return std::make_shared<TranslationModel>(config, std::move(memoryBundle));
 }
 

--- a/wasm/bindings/service_bindings.cpp
+++ b/wasm/bindings/service_bindings.cpp
@@ -45,7 +45,8 @@ std::vector<std::shared_ptr<AlignedMemory>> prepareVocabsSmartMemories(std::vect
 }
 
 MemoryBundle prepareMemoryBundle(AlignedMemory* modelMemory, AlignedMemory* shortlistMemory,
-                                 std::vector<AlignedMemory*> uniqueVocabsMemories, AlignedMemory* qualityEstimatorMemory) {
+                                 std::vector<AlignedMemory*> uniqueVocabsMemories,
+                                 AlignedMemory* qualityEstimatorMemory) {
   MemoryBundle memoryBundle;
   memoryBundle.model = std::move(*modelMemory);
   memoryBundle.shortlist = std::move(*shortlistMemory);
@@ -60,8 +61,8 @@ MemoryBundle prepareMemoryBundle(AlignedMemory* modelMemory, AlignedMemory* shor
 // This allows only shared_ptrs to be operational in JavaScript, according to emscripten.
 // https://emscripten.org/docs/porting/connecting_cpp_and_javascript/embind.html#smart-pointers
 std::shared_ptr<TranslationModel> TranslationModelFactory(const std::string& config, AlignedMemory* model,
-                                                          AlignedMemory* shortlist,
-                                                          std::vector<AlignedMemory*> vocabs, AlignedMemory* qualityEstimator) {
+                                                          AlignedMemory* shortlist, std::vector<AlignedMemory*> vocabs,
+                                                          AlignedMemory* qualityEstimator) {
   MemoryBundle memoryBundle = prepareMemoryBundle(model, shortlist, vocabs, qualityEstimator);
   return std::make_shared<TranslationModel>(config, std::move(memoryBundle));
 }


### PR DESCRIPTION
Fixes: https://github.com/browsermt/bergamot-translator/issues/318

Modified the wasm test page and tested it there. It works.
Supervised QE binary models are being used for 3 language pairs.