### PR TITLE
JS: Fix swap button on test-page

### DIFF
--- a/wasm/test_page/js/index.js
+++ b/wasm/test_page/js/index.js
@@ -111,7 +111,7 @@ langTo.addEventListener("change", e => {
 
 $(".swap").addEventListener("click", e => {
   [langFrom.value, langTo.value] = [langTo.value, langFrom.value];
-  $("#input").value = $("#output").value;
+  $("#input").value = $("#output").innerHTML;
   loadModel();
 });
 

--- a/wasm/test_page/js/index.js
+++ b/wasm/test_page/js/index.js
@@ -111,7 +111,7 @@ langTo.addEventListener("change", e => {
 
 $(".swap").addEventListener("click", e => {
   [langFrom.value, langTo.value] = [langTo.value, langFrom.value];
-  $("#input").value = $("#output").innerHTML;
+  $("#input").value = $("#output").innerText;
   loadModel();
 });
 


### PR DESCRIPTION
https://github.com/browsermt/bergamot-translator/pull/358 changed a text area to a div to show quality UI renders, causing the code that swapped content on click of the button to populate instead with `undefined`.

This change uses `innerText` on the output to populate input to fix the issue.