### PR TITLE
Fix call to `std::isspace`

### DIFF
--- a/src/translator/html.cpp
+++ b/src/translator/html.cpp
@@ -48,7 +48,7 @@ void encodeEntities(marian::string_view const &input, std::string &output) {
 /// for determining where to insert an open or close tag.
 size_t countPrefixWhitespaces(marian::string_view const &input) {
   size_t size = 0;
-  while (size < input.size() && std::isspace(input[size])) ++size;
+  while (size < input.size() && std::isspace(static_cast<unsigned char>(input[size]))) ++size;
   return size;
 }
 


### PR DESCRIPTION
[The documentation](https://en.cppreference.com/w/cpp/string/byte/isspace) is explicit about only calling it with unsigned char, and Windows runtime is checking this.