### PR TITLE
Android ARM-64 Build

### DIFF
--- a/.github/workflows/arm.yml
+++ b/.github/workflows/arm.yml
@@ -68,14 +68,14 @@ jobs:
         ccache -s # Print current cache stats
         ccache -z # Zero cache entry
 
-    - name: Generate buildfiles for marian on android via cmake
+    - name: Generate buildfiles for bergamot-translator on android via cmake
       run: |-
         mkdir -p build 
         cd build
         NDK=${{ env.ndk }}
         ABI=${{ env.abi }}
         MINSDK_VERSION=${{ env.minsdk_version }}
-        ANDROID_PLATFORM=${{ env.android_platform }}
+        ANDROID_PLATFORM=android-${{ env.android_platform }}
         OTHER_ANDROID_ARGS=(
             -DANDROID_ARM_NEON=TRUE
         )
@@ -88,6 +88,7 @@ jobs:
             -DTHREADS_PREFER_PTHREAD_FLAG=ON
             -DBUILD_ARCH=armv8-a
             # -DCOMPILE_WITHOUT_EXCEPTIONS=on # Apparently this can reduce the binary size, let's see.
+            -DSSPLIT_USE_INTERNAL_PCRE2=ON
         )
         # Additionally list variables finally configured.
         cmake -L \
@@ -104,7 +105,7 @@ jobs:
             ..
 
 
-    - name : Build marian for android
+    - name : Build bergamot-translator for android
       working-directory: build
       run: |-
           make -j2 

--- a/.github/workflows/arm.yml
+++ b/.github/workflows/arm.yml
@@ -1,0 +1,138 @@
+name: ARM
+'on':
+  push:
+    branches:
+    - main
+    - ci-sandbox
+  pull_request:
+    branches:
+    - '**'
+env:
+  ccache_basedir: ${{ github.workspace }}
+  ccache_dir: "${{ github.workspace }}/.ccache"
+  ccache_compilercheck: content
+  ccache_compress: 'true'
+  ccache_compresslevel: 9
+  ccache_maxsize: 200M
+  ccache_cmake: -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
+  ndk: "${{ github.workspace }}/android-ndk-r23b"
+  abi: "arm64-v8a"
+  minsdk_version : 28
+  android_platform: 28
+
+jobs:
+  ubuntu:
+    name: "arm-v8a cross-compile via Android NDK"
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - name: Install prerequisites
+      run: |
+          wget -c --quiet https://dl.google.com/android/repository/android-ndk-r23b-linux.zip
+          unzip -qq android-ndk-r23b-linux.zip
+          sudo apt-get -y install ccache cmake
+
+    - name: Generate ccache_vars for ccache based on machine
+      shell: bash
+      id: ccache_vars
+      run: |-
+        echo "::set-output name=hash::$(echo ${{ env.ccache_compilercheck }})"
+        echo "::set-output name=timestamp::$(date '+%Y-%m-%dT%H.%M.%S')"
+
+    - name: Cache-op for build-cache through ccache
+      uses: actions/cache@v2
+      with:
+        path: ${{ env.ccache_dir }}
+        key: ccache-${{ matrix.identifier }}-${{ steps.ccache_vars.outputs.hash }}-${{ github.ref }}-${{ steps.ccache_vars.outputs.timestamp }}
+        restore-keys: |-
+          ccache-${{ matrix.identifier }}-${{ steps.ccache_vars.outputs.hash }}-${{ github.ref }}
+          ccache-${{ matrix.identifier }}-${{ steps.ccache_vars.outputs.hash }}
+          ccache-${{ matrix.identifier }}
+
+    - name: ccache environment setup
+      run: |-
+        echo "CCACHE_COMPILER_CHECK=${{ env.ccache_compilercheck }}" >> $GITHUB_ENV
+        echo "CCACHE_BASEDIR=${{ env.ccache_basedir }}" >> $GITHUB_ENV
+        echo "CCACHE_COMPRESS=${{ env.ccache_compress }}" >> $GITHUB_ENV
+        echo "CCACHE_COMPRESSLEVEL=${{ env.ccache_compresslevel }}" >> $GITHUB_ENV
+        echo "CCACHE_DIR=${{ env.ccache_dir }}" >> $GITHUB_ENV
+        echo "CCACHE_MAXSIZE=${{ env.ccache_maxsize }}" >> $GITHUB_ENV
+
+    - name: ccache prolog
+      run: |-
+        ccache -s # Print current cache stats
+        ccache -z # Zero cache entry
+
+    - name: Generate buildfiles for marian on android via cmake
+      run: |-
+        mkdir -p build 
+        cd build
+        NDK=${{ env.ndk }}
+        ABI=${{ env.abi }}
+        MINSDK_VERSION=${{ env.minsdk_version }}
+        ANDROID_PLATFORM=${{ env.android_platform }}
+        OTHER_ANDROID_ARGS=(
+            -DANDROID_ARM_NEON=TRUE
+        )
+        OTHER_MARIAN_ARGS=(
+            -DCOMPILE_CUDA=off
+            -DCOMPILE_CPU=on
+            -DCMAKE_HAVE_THREADS_LIBRARY=1
+            -DCMAKE_USE_WIN32_THREADS_INIT=0
+            -DCMAKE_USE_PTHREADS_INIT=1
+            -DTHREADS_PREFER_PTHREAD_FLAG=ON
+            -DBUILD_ARCH=armv8-a
+            # -DCOMPILE_WITHOUT_EXCEPTIONS=on # Apparently this can reduce the binary size, let's see.
+        )
+        # Additionally list variables finally configured.
+        cmake -L \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_TOOLCHAIN_FILE=$NDK/build/cmake/android.toolchain.cmake \
+            -DANDROID_TOOLCHAIN=clang \
+            -DANDROID_ABI=$ABI \
+            -DANDROID_PLATFORM=$ANDROID_PLATFORM \
+            -DANDROID_NATIVE_API_LEVEL=$MINSDKVERSION \
+            -DANDROID_TOOLCHAIN_NAME=arm-linux-androideabi-4.8 \
+            -DANDROID_STL=c++_static \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            "${OTHER_ANDROID_ARGS[@]}" "${OTHER_MARIAN_ARGS[@]}" \
+            ..
+
+
+    - name : Build marian for android
+      working-directory: build
+      run: |-
+          make -j2 
+
+    - name: ccache epilog
+      run: 'ccache -s # Print current cache stats'
+
+    - uses: actions/upload-artifact@v2
+      with:
+        path: ${{github.workspace}}/build/app/bergamot
+
+
+  # Disable release for now.
+  # release:
+  #   name: Release Latest Build
+  #   runs-on: ubuntu-latest
+  #   needs: [ubuntu]
+  #   if: github.ref == 'refs/heads/master'
+  #   steps:
+  #    - name: Download artifacts
+  #      uses: actions/download-artifact@v2
+  #     
+  #    - name: Update GitHub prerelease
+  #      uses: marvinpinto/action-automatic-releases@latest
+  #      with:
+  #        repo_token: ${{ secrets.GITHUB_TOKEN }}
+  #        automatic_release_tag: latest
+  #        prerelease: true
+  #        title: "Latest Build"
+  #        files: |
+  #          artifact/marian-decoder

--- a/3rd_party/CMakeLists.txt
+++ b/3rd_party/CMakeLists.txt
@@ -19,6 +19,12 @@ target_include_directories(marian PUBLIC ${INCDIRS})
 get_property(INCLUDE_DIRECTORIES DIRECTORY ssplit-cpp/src PROPERTY INCLUDE_DIRECTORIES)
 target_include_directories(ssplit PUBLIC ${INCLUDE_DIRECTORIES})
 
+get_property(COMPILE_DEFINITIONS DIRECTORY marian-dev PROPERTY COMPILE_DEFINITIONS) 
+target_compile_definitions(marian PUBLIC ${COMPILE_DEFINITIONS})
+
+get_property(COMPILE_OPTIONS DIRECTORY marian-dev PROPERTY COMPILE_OPTIONS) 
+target_compile_options(marian PUBLIC ${COMPILE_OPTIONS})
+
 # Compilation flags 
 get_directory_property(CMAKE_C_FLAGS DIRECTORY marian-dev DEFINITION CMAKE_C_FLAGS) 
 get_directory_property(CMAKE_CXX_FLAGS DIRECTORY marian-dev DEFINITION CMAKE_CXX_FLAGS) 

--- a/bindings/python/bergamot.cpp
+++ b/bindings/python/bergamot.cpp
@@ -38,9 +38,8 @@ class ServicePyAdapter {
     marian::setThrowExceptionOnAbort(true);
   }
 
-  std::shared_ptr<_Model> modelFromConfig(const std::string &config, bool validate = true,
-                                          const std::string &base_dir = "") {
-    auto parsedConfig = marian::bergamot::parseOptionsFromString(config, validate, base_dir);
+  std::shared_ptr<_Model> modelFromConfig(const std::string &config) {
+    auto parsedConfig = marian::bergamot::parseOptionsFromString(config);
     return service_.createCompatibleModel(parsedConfig);
   }
 

--- a/bindings/python/bergamot.cpp
+++ b/bindings/python/bergamot.cpp
@@ -38,8 +38,9 @@ class ServicePyAdapter {
     marian::setThrowExceptionOnAbort(true);
   }
 
-  std::shared_ptr<_Model> modelFromConfig(const std::string &config) {
-    auto parsedConfig = marian::bergamot::parseOptionsFromString(config);
+  std::shared_ptr<_Model> modelFromConfig(const std::string &config, bool validate = true,
+                                          const std::string &base_dir = "") {
+    auto parsedConfig = marian::bergamot::parseOptionsFromString(config, validate, base_dir);
     return service_.createCompatibleModel(parsedConfig);
   }
 

--- a/bindings/python/cmds.py
+++ b/bindings/python/cmds.py
@@ -3,6 +3,7 @@ import sys
 from collections import Counter, defaultdict
 
 from . import REPOSITORY, ResponseOptions, Service, ServiceConfig, VectorString
+from .utils import patched_platform_from_config_path
 
 CMDS = {}
 
@@ -74,12 +75,11 @@ class Translate:
         config = ServiceConfig(numWorkers=args.num_workers, logLevel=args.log_level)
         service = Service(config)
 
-        models = [
-            service.modelFromConfigPath(
-                REPOSITORY.modelConfigPath(args.repository, model)
-            )
-            for model in args.model
-        ]
+        models = []
+        for model in args.model:
+            configPath = REPOSITORY.modelConfigPath(args.repository, model)
+            config = patched_platform_from_config_path(configPath)
+            models.append(service.modelFromConfig(config, True, configPath))
 
         # Configure a few options which require how a Response is constructed
         options = ResponseOptions(

--- a/bindings/python/cmds.py
+++ b/bindings/python/cmds.py
@@ -3,7 +3,6 @@ import sys
 from collections import Counter, defaultdict
 
 from . import REPOSITORY, ResponseOptions, Service, ServiceConfig, VectorString
-from .utils import patched_platform_from_config_path
 
 CMDS = {}
 
@@ -75,11 +74,12 @@ class Translate:
         config = ServiceConfig(numWorkers=args.num_workers, logLevel=args.log_level)
         service = Service(config)
 
-        models = []
-        for model in args.model:
-            configPath = REPOSITORY.modelConfigPath(args.repository, model)
-            config = patched_platform_from_config_path(configPath)
-            models.append(service.modelFromConfig(config, True, configPath))
+        models = [
+            service.modelFromConfigPath(
+                REPOSITORY.modelConfigPath(args.repository, model)
+            )
+            for model in args.model
+        ]
 
         # Configure a few options which require how a Response is constructed
         options = ResponseOptions(

--- a/bindings/python/utils.py
+++ b/bindings/python/utils.py
@@ -1,5 +1,4 @@
 import os
-import platform
 
 import requests
 import yaml
@@ -51,17 +50,3 @@ def patch_marian_for_bergamot(
     # Write-out.
     with open(bergamot_config_path, "w") as output_file:
         print(yaml.dump(data, sort_keys=False), file=output_file)
-
-
-def patched_platform_from_config_path(bergamot_config_path: PathLike) -> str:
-    data = None
-    with open(bergamot_config_path) as bergamot_config_file:
-        data = yaml.load(bergamot_config_file, Loader=yaml.FullLoader)
-        if "int8" in data["gemm-precision"]:
-            processor = platform.processor()
-            if processor in ["arm64", "aarch64"]:
-                # Remove shift, because the path available only on intel.
-                data["gemm-precision"] = data["gemm-precision"].replace("shift", "")
-                data["gemm-precision"] = data["gemm-precision"].replace("All", "")
-
-    return yaml.dump(data, sort_keys=False)

--- a/bindings/python/utils.py
+++ b/bindings/python/utils.py
@@ -1,4 +1,5 @@
 import os
+import platform
 
 import requests
 import yaml
@@ -50,3 +51,17 @@ def patch_marian_for_bergamot(
     # Write-out.
     with open(bergamot_config_path, "w") as output_file:
         print(yaml.dump(data, sort_keys=False), file=output_file)
+
+
+def patched_platform_from_config_path(bergamot_config_path: PathLike) -> str:
+    data = None
+    with open(bergamot_config_path) as bergamot_config_file:
+        data = yaml.load(bergamot_config_file, Loader=yaml.FullLoader)
+        if "int8" in data["gemm-precision"]:
+            processor = platform.processor()
+            if processor in ["arm64", "aarch64"]:
+                # Remove shift, because the path available only on intel.
+                data["gemm-precision"] = data["gemm-precision"].replace("shift", "")
+                data["gemm-precision"] = data["gemm-precision"].replace("All", "")
+
+    return yaml.dump(data, sort_keys=False)


### PR DESCRIPTION
Adds a CI using Android NDK and changes to `CMakeLists.txt` to build on Android.

PRs to be merged before this:
- https://github.com/browsermt/marian-dev/pull/79
- https://github.com/browsermt/ssplit-cpp/pull/13

Issues:
- ARM only supports `int8`, `int8Alpha`, `int8AlphaAll`. The `*shift*` versions are unusable. Supplied configuration files from models in [`translateLocally.json`](https://translatelocally.com/models.json) comes with an `x86_64` assumption which will need platform detect and choosing at each client. 