### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     build-wheels:
       strategy:
         matrix:
-          os: [ubuntu-20.04, macos-10.15]
+          os: [ubuntu-latest, macos-latest]
         fail-fast: false
 
       name: "cibuildwheel / ${{ matrix.os }}"
@@ -281,7 +281,7 @@ jobs:
                 ${{github.workspace}}/build-wasm/bergamot-translator-worker.wasm
                 ${{github.workspace}}/build-wasm/bergamot-translator-worker.js.bak
 
-    
+
     upload-wasm:
       name: "Upload node package to NPM"
       runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -383,7 +383,7 @@ jobs:
             python3 -m pytype bindings/python
 
     docs:
-      runs-on: ubuntu-18.04
+      runs-on: ubuntu-latest
       needs: [build-wheels]
       steps:
         - name: Checkout


### PR DESCRIPTION
Fixes CI for cibuildwheel and docs
If we want to enable Python 3.11 then we'll have to update our cibuildwheel action beyond 2.6.1


MacOS based native builds should start working with https://github.com/browsermt/bergamot-translator-tests/pull/63 and a the corresponding submodule update.