### PR TITLE
Report the wasm size on builds

### DIFF
--- a/build-wasm.sh
+++ b/build-wasm.sh
@@ -44,5 +44,22 @@ emmake make -j2
 #     2. Import GEMM library from a separate wasm module
 bash ../wasm/patch-artifacts-import-gemm-module.sh
 
+set +x
+echo ""
+echo "Build complete"
+echo ""
+echo "  ./build-wasm/bergamot-translator-worker.js"
+echo "  ./build-wasm/bergamot-translator-worker.wasm"
+
+WASM_SIZE=$(wc -c bergamot-translator-worker.wasm | awk '{print $1}')
+GZIP_SIZE=$(gzip -c bergamot-translator-worker.wasm | wc -c | xargs) # xargs trims the whitespace
+
+# Convert it to human readable.
+WASM_SIZE="$(awk 'BEGIN {printf "%.2f",'$WASM_SIZE'/1048576}')M ($WASM_SIZE bytes)"
+GZIP_SIZE="$(awk 'BEGIN {printf "%.2f",'$GZIP_SIZE'/1048576}')M ($GZIP_SIZE bytes)"
+
+echo "  Uncompressed wasm size: $WASM_SIZE"
+echo "  Compressed wasm size: $GZIP_SIZE"
+
 # The artifacts (.js and .wasm files) will be available in the build directory
 exit 0


### PR DESCRIPTION
The size of the wasm bundle affects the speed at which it can be loaded in the browser. This PR adds a report to the `build-wasm.sh` that shows the size both uncompressed, and compressed. The compressed size is generally what is actually downloaded by the end user.

Here is a sample output:

```
[ 98%] Linking CXX executable ../bergamot-translator-worker.js
'+sse2' is not a recognized feature for this target (ignoring feature)
'+sse2' is not a recognized feature for this target (ignoring feature)
'+ssse3' is not a recognized feature for this target (ignoring feature)
'+ssse3' is not a recognized feature for this target (ignoring feature)
warning: undefined symbol: int8_multiply_and_add_bias (referenced by top-level compiled C/C++ code)
warning: undefined symbol: int8_prepare_a (referenced by top-level compiled C/C++ code)
warning: undefined symbol: int8_prepare_b (referenced by top-level compiled C/C++ code)
warning: undefined symbol: int8_prepare_b_from_quantized_transposed (referenced by top-level compiled C/C++ code)
warning: undefined symbol: int8_prepare_b_from_transposed (referenced by top-level compiled C/C++ code)
warning: undefined symbol: int8_prepare_bias (referenced by top-level compiled C/C++ code)
warning: undefined symbol: int8_select_columns_of_b (referenced by top-level compiled C/C++ code)
warning: undefined symbol: pclose (referenced by top-level compiled C/C++ code)
[100%] Built target bergamot-translator-worker
+ bash ../wasm/patch-artifacts-import-gemm-module.sh
Importing integer (8-bit) gemm implementation
SUCCESS
+ set +x

Build complete

  ./build-wasm/bergamot-translator-worker.js
  ./build-wasm/bergamot-translator-worker.wasm
  Uncompressed wasm size: 5.00M (5246440 bytes)
  Compressed wasm size: 1.77M (1856341 bytes)
```