### PR TITLE
Generate a compile_commands.json by default with cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,10 @@ project(bergamot_translator CXX C)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Generate a compile_commands.json in the build directory. The compile commands allow
+# code editors to understand the build process and provide static analysis of the code.
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # Note that with CMake MSVC build, the option CMAKE_BUILD_TYPE is automatically derived from the key
 # 'configurationType' in CMakeSettings.json configurations
 if(NOT CMAKE_BUILD_TYPE)


### PR DESCRIPTION
I use vscode, and this is required to get the in-editor language server working. This is a standardized file that other editors can use as well to understand the C++ code.

https://clang.llvm.org/docs/JSONCompilationDatabase.html

The following is an example of the language server providing type information.

<img width="715" alt="image" src="https://github.com/browsermt/bergamot-translator/assets/1588648/6b12481e-7c7d-4241-b393-1aed4b4c8611">
