### PR TITLE
Add more things to the gitignore that are not being ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,10 @@ _deps
 
 
 wasm/test_page/node_modules
-build-wasm
+/build
+/build-native
+/build-wasm
+/emsdk
 models
 wasm/module/worker/bergamot-translator-worker.*
 wasm/module/browsermt-bergamot-translator-*.tgz


### PR DESCRIPTION
This adds more items to the project's .gitignore that are not being ignored. I could add them to my global gitignore, but it seems to make sense to add them to the project itself. Note that I added `/build` as well as `/build-native` as it's a common cmake practice to use `/build` as the build directory. The `emsdk` folder is generated by the `./build-wasm.sh` command.