### PR TITLE
model name update in download url in example script

### DIFF
--- a/examples/run-native.sh
+++ b/examples/run-native.sh
@@ -3,8 +3,8 @@
 # Obtain an example model from the web.
 mkdir -p models
 wget --quiet --continue --directory models/ \
-    http://data.statmt.org/bergamot/models/deen/ende.student.tiny11.tar.gz 
-(cd models && tar -xzf ende.student.tiny11.tar.gz)
+    https://data.statmt.org/bergamot/models/deen/ende.student.tiny11.v2.93821e13b3c511b5.tar.gz
+(cd models && tar -xzf ende.student.tiny11.v2.93821e13b3c511b5.tar.gz)
 
 # Patch the config-files generated from marian for use in bergamot.
 python3 bergamot-translator-tests/tools/patch-marian-for-bergamot.py \


### PR DESCRIPTION
The model name in the download url for de-en translation in example script seems to have changed from `ende.student.tiny11.tar.gz` to `ende.student.tiny11.v2.93821e13b3c511b5.tar.gz`. I have updated the download url in this pr.