### PR TITLE
fix downloading of models in the python binding

### DIFF
--- a/bindings/python/repository.py
+++ b/bindings/python/repository.py
@@ -180,7 +180,7 @@ class TranslateLocallyLike(Repository):
     def _archive_name_without_extension(self, url: URL):
         o = urlparse(url)
         fname = os.path.basename(o.path)  # something tar.gz.
-        fname_without_extension = fname.replace(".tar.gz", "")
+        fname_without_extension = ".".join(fname.split(".")[:3])
         return fname_without_extension
 
 


### PR DESCRIPTION
models come in files named like `csen.student.base.v1.cd5418ba6a412fc7.tar.gz`, but the directory they create when extracted are named like `csen.student.base`. we therefore need to remove not just the extension but everything following and including the 3rd period