### PR TITLE
fixed bug that prevented "download all" functionality

### DIFF
--- a/bindings/python/repository.py
+++ b/bindings/python/repository.py
@@ -32,7 +32,7 @@ class Repository(ABC):
         pass
 
     @abstractmethod
-    def models(self) -> t.List[str]:
+    def models(self, filter_downloaded: bool = True) -> t.List[str]:
         """returns identifiers for available models"""
         pass
 
@@ -204,7 +204,7 @@ class Aggregator:
         )
 
     def models(self, name: str, filter_downloaded: bool = True) -> t.List[str]:
-        return self.repositories.get(name, self.default_repository).models()
+        return self.repositories.get(name, self.default_repository).models(filter_downloaded)
 
     def model(self, name: str, model_identifier: str) -> t.Any:
         return self.repositories.get(name, self.default_repository).model(


### PR DESCRIPTION
`Aggregator.models` wasn't passing the value for `filter_downloaded` through to the `models` method of the `Repository` subclass. This means that by default the subclass's `models` method always fired with `filter_downloaded=True`, which meant that if there were no models already downloaded, calling `bergamot download` didn't download anything as it couldn't discover the undownloaded models. This PR fixes this behaviour.